### PR TITLE
Feat/prisma importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ node_modules/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+project.md
+CLAUDE.md
+.claude

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +66,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -57,6 +153,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +181,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pest"
@@ -190,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +324,7 @@ dependencies = [
 name = "transf-orm-cli"
 version = "0.0.1"
 dependencies = [
+ "clap",
  "pest",
  "pest_derive",
  "serde",
@@ -229,10 +350,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,119 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -76,6 +179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,15 +204,35 @@ dependencies = [
 name = "transf-orm-cli"
 version = "0.0.1"
 dependencies = [
+ "pest",
+ "pest_derive",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+pest = "2"
+pest_derive = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+clap = { version = "4", features = ["derive"] }
 pest = "2"
 pest_derive = "2"

--- a/result
+++ b/result
@@ -1,0 +1,2686 @@
+{
+  "pivotVersion": "1.0.0",
+  "database": "postgreSql",
+  "dialectVersion": null,
+  "dbSchemas": [],
+  "extensions": [],
+  "tables": [
+    {
+      "name": "User",
+      "dbName": "users",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "uuid"
+          }
+        },
+        {
+          "name": "email",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 255
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "username",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 50
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "displayName",
+          "dbName": "display_name",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 100
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "bio",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "text"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "role",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "enum",
+              "name": "Role"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "string",
+              "value": "USER"
+            }
+          }
+        },
+        {
+          "name": "score",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": {
+              "kind": "smallInt"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "int",
+              "value": 0
+            }
+          }
+        },
+        {
+          "name": "balance",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "decimal",
+              "precision": 65,
+              "scale": 30
+            },
+            "dbHint": {
+              "kind": "numeric",
+              "precision": 12,
+              "scale": 2
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "int",
+              "value": 0
+            }
+          }
+        },
+        {
+          "name": "metadata",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "json"
+            },
+            "dbHint": {
+              "kind": "custom",
+              "type_expr": "JsonB"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "ipAddress",
+          "dbName": "ip_address",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "inet"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "tags",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": null,
+            "array": true
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "createdAt",
+          "dbName": "created_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        },
+        {
+          "name": "updatedAt",
+          "dbName": "updated_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "deletedAt",
+          "dbName": "deleted_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "createdAt",
+              "sort": "desc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        },
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "email",
+              "sort": "asc",
+              "nulls": null
+            },
+            {
+              "column": "username",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": {
+            "kind": "hash"
+          },
+          "include": []
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": null,
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": null,
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Profile"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Profile",
+          "toFields": [
+            "userId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Post"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Post",
+          "toFields": [
+            "authorId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Comment"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Comment",
+          "toFields": [
+            "authorId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": "ReviewAuthor",
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Review"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Review",
+          "toFields": [
+            "authorId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        },
+        {
+          "name": "ReviewTarget",
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Review"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Review",
+          "toFields": [
+            "targetId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Order"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Order",
+          "toFields": [
+            "userId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [
+        {
+          "kind": "updatedAt",
+          "column": "updatedAt"
+        }
+      ],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Profile",
+      "dbName": "profiles",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "userId",
+          "dbName": "user_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "website",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 500
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "location",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 100
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "birthDate",
+          "dbName": "birth_date",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": {
+              "kind": "date"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "timezone",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 50
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "string",
+              "value": "UTC"
+            }
+          }
+        },
+        {
+          "name": "rawConfig",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "unsupported",
+              "type_name": "hstore"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": "pk_profile",
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [],
+      "uniqueConstraints": [
+        {
+          "name": null,
+          "columns": [
+            "userId"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "userId"
+          ],
+          "referencedTable": "User",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Profile"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Profile",
+          "toFields": [
+            "userId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Post",
+      "dbName": "posts",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "slug",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 255
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "title",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 500
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "content",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "text"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "excerpt",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 300
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "status",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "enum",
+              "name": "PostStatus"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "string",
+              "value": "DRAFT"
+            }
+          }
+        },
+        {
+          "name": "viewCount",
+          "dbName": "view_count",
+          "type": {
+            "scalar": {
+              "kind": "bigInt"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "int",
+              "value": 0
+            }
+          }
+        },
+        {
+          "name": "rating",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "double"
+            },
+            "dbHint": {
+              "kind": "doublePrecision"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "int",
+              "value": 0
+            }
+          }
+        },
+        {
+          "name": "publishedAt",
+          "dbName": "published_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": {
+              "kind": "timestamp",
+              "precision": 3
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "authorId",
+          "dbName": "author_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "createdAt",
+          "dbName": "created_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        },
+        {
+          "name": "updatedAt",
+          "dbName": "updated_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "internalNote",
+          "dbName": "internal_note",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "text"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "status",
+              "sort": "asc",
+              "nulls": null
+            },
+            {
+              "column": "publishedAt",
+              "sort": "desc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        },
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "authorId",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        },
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "title",
+              "sort": "asc",
+              "nulls": null
+            },
+            {
+              "column": "content",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": {
+            "kind": "custom",
+            "name": "fulltext"
+          },
+          "include": []
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": null,
+          "columns": [
+            "slug"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "authorId"
+          ],
+          "referencedTable": "User",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Post",
+          "toFields": [
+            "authorId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Comment"
+          },
+          "fromTable": "Post",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Comment",
+          "toFields": [
+            "postId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Media"
+          },
+          "fromTable": "Post",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Media",
+          "toFields": [
+            "postId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "manyToMany",
+            "junction": {
+              "table": "_PostToTag",
+              "fromColumn": "A",
+              "toColumn": "B"
+            },
+            "implicit": true
+          },
+          "fromTable": "Post",
+          "fromFields": [],
+          "toTable": "Tag",
+          "toFields": [],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [
+        {
+          "kind": "updatedAt",
+          "column": "updatedAt"
+        }
+      ],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": [
+          {
+            "name": "prisma.ignoredFields",
+            "value": [
+              "internalNote"
+            ],
+            "recoverable": true
+          }
+        ]
+      }
+    },
+    {
+      "name": "Comment",
+      "dbName": "comments",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "content",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "text"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "postId",
+          "dbName": "post_id",
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "authorId",
+          "dbName": "author_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "parentId",
+          "dbName": "parent_id",
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "createdAt",
+          "dbName": "created_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        },
+        {
+          "name": "updatedAt",
+          "dbName": "updated_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "postId",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        },
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "authorId",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        }
+      ],
+      "uniqueConstraints": [],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "postId"
+          ],
+          "referencedTable": "Post",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": null
+        },
+        {
+          "name": null,
+          "columns": [
+            "authorId"
+          ],
+          "referencedTable": "User",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": null
+        },
+        {
+          "name": null,
+          "columns": [
+            "parentId"
+          ],
+          "referencedTable": "Comment",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": null,
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "Post",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Comment",
+          "toFields": [
+            "postId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Comment",
+          "toFields": [
+            "authorId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": "CommentReplies",
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "Comment"
+          },
+          "fromTable": "Comment",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Comment",
+          "toFields": [
+            "parentId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [
+        {
+          "kind": "updatedAt",
+          "column": "updatedAt"
+        }
+      ],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Tag",
+      "dbName": "tags",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "name",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 100
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "slug",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 100
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [],
+      "uniqueConstraints": [
+        {
+          "name": null,
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "name": null,
+          "columns": [
+            "slug"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "manyToMany",
+            "junction": {
+              "table": "_PostToTag",
+              "fromColumn": "A",
+              "toColumn": "B"
+            },
+            "implicit": true
+          },
+          "fromTable": "Tag",
+          "fromFields": [],
+          "toTable": "Post",
+          "toFields": [],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Media",
+      "dbName": "media",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "url",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 1000
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "mimeType",
+          "dbName": "mime_type",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 100
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "sizeBytes",
+          "dbName": "size_bytes",
+          "type": {
+            "scalar": {
+              "kind": "bigInt"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "width",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": {
+              "kind": "smallInt"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "height",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": {
+              "kind": "smallInt"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "postId",
+          "dbName": "post_id",
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [],
+      "uniqueConstraints": [],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "postId"
+          ],
+          "referencedTable": "Post",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "Post",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Media",
+          "toFields": [
+            "postId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Review",
+      "dbName": "reviews",
+      "dbSchema": "public",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "rating",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": {
+              "kind": "smallInt"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "comment",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "text"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "authorId",
+          "dbName": "author_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "targetId",
+          "dbName": "target_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "createdAt",
+          "dbName": "created_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [],
+      "uniqueConstraints": [
+        {
+          "name": "uq_review_author_target",
+          "columns": [
+            "authorId",
+            "targetId"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "authorId"
+          ],
+          "referencedTable": "User",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": null,
+          "onUpdate": null
+        },
+        {
+          "name": null,
+          "columns": [
+            "targetId"
+          ],
+          "referencedTable": "User",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": null,
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": "ReviewAuthor",
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Review",
+          "toFields": [
+            "authorId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        },
+        {
+          "name": "ReviewTarget",
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Review",
+          "toFields": [
+            "targetId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Product",
+      "dbName": "products",
+      "dbSchema": "shop",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "sku",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 100
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "name",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 500
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "description",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "text"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "price",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "decimal",
+              "precision": 65,
+              "scale": 30
+            },
+            "dbHint": {
+              "kind": "numeric",
+              "precision": 10,
+              "scale": 2
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "stock",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "int",
+              "value": 0
+            }
+          }
+        },
+        {
+          "name": "attributes",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "json"
+            },
+            "dbHint": {
+              "kind": "custom",
+              "type_expr": "JsonB"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "string",
+              "value": "{}"
+            }
+          }
+        },
+        {
+          "name": "isActive",
+          "dbName": "is_active",
+          "type": {
+            "scalar": {
+              "kind": "boolean"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "bool",
+              "value": true
+            }
+          }
+        },
+        {
+          "name": "createdAt",
+          "dbName": "created_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        }
+      ],
+      "primaryKey": {
+        "name": "pk_product",
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "name",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": {
+            "kind": "bTree"
+          },
+          "include": []
+        },
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "name",
+              "sort": "asc",
+              "nulls": null
+            },
+            {
+              "column": "description",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": {
+            "kind": "custom",
+            "name": "fulltext"
+          },
+          "include": []
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": null,
+          "columns": [
+            "sku"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "OrderItem"
+          },
+          "fromTable": "Product",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "OrderItem",
+          "toFields": [
+            "productId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Order",
+      "dbName": "orders",
+      "dbSchema": "shop",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "reference",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 36
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "raw",
+            "value": "gen_random_uuid()"
+          }
+        },
+        {
+          "name": "status",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "enum",
+              "name": "OrderStatus"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "string",
+              "value": "PENDING"
+            }
+          }
+        },
+        {
+          "name": "total",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "decimal",
+              "precision": 65,
+              "scale": 30
+            },
+            "dbHint": {
+              "kind": "numeric",
+              "precision": 10,
+              "scale": 2
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "userId",
+          "dbName": "user_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "shippedAt",
+          "dbName": "shipped_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": {
+              "kind": "timestamp",
+              "precision": 0
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "createdAt",
+          "dbName": "created_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        },
+        {
+          "name": "updatedAt",
+          "dbName": "updated_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "userId",
+              "sort": "asc",
+              "nulls": null
+            },
+            {
+              "column": "status",
+              "sort": "asc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        },
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "createdAt",
+              "sort": "desc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        }
+      ],
+      "uniqueConstraints": [
+        {
+          "name": null,
+          "columns": [
+            "reference"
+          ]
+        }
+      ],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "userId"
+          ],
+          "referencedTable": "User",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": null,
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "User",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "Order",
+          "toFields": [
+            "userId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToOne",
+            "owner_table": "OrderItem"
+          },
+          "fromTable": "Order",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "OrderItem",
+          "toFields": [
+            "orderId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [
+        {
+          "kind": "updatedAt",
+          "column": "updatedAt"
+        }
+      ],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "OrderItem",
+      "dbName": "order_items",
+      "dbSchema": "shop",
+      "columns": [
+        {
+          "name": "orderId",
+          "dbName": "order_id",
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "productId",
+          "dbName": "product_id",
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "quantity",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "int"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "unitPrice",
+          "dbName": "unit_price",
+          "type": {
+            "scalar": {
+              "kind": "decimal",
+              "precision": 65,
+              "scale": 30
+            },
+            "dbHint": {
+              "kind": "numeric",
+              "precision": 10,
+              "scale": 2
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "orderId",
+          "productId"
+        ]
+      },
+      "indexes": [],
+      "uniqueConstraints": [],
+      "checkConstraints": [],
+      "foreignKeys": [
+        {
+          "name": null,
+          "columns": [
+            "orderId"
+          ],
+          "referencedTable": "Order",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": null
+        },
+        {
+          "name": null,
+          "columns": [
+            "productId"
+          ],
+          "referencedTable": "Product",
+          "referencedColumns": [
+            "id"
+          ],
+          "onDelete": null,
+          "onUpdate": null
+        }
+      ],
+      "relations": [
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "Order",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "OrderItem",
+          "toFields": [
+            "orderId"
+          ],
+          "cascade": {
+            "onDelete": "cascade",
+            "onUpdate": null
+          }
+        },
+        {
+          "name": null,
+          "kind": {
+            "kind": "oneToMany"
+          },
+          "fromTable": "Product",
+          "fromFields": [
+            "id"
+          ],
+          "toTable": "OrderItem",
+          "toFields": [
+            "productId"
+          ],
+          "cascade": {
+            "onDelete": null,
+            "onUpdate": null
+          }
+        }
+      ],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    },
+    {
+      "name": "Event",
+      "dbName": "events",
+      "dbSchema": "analytics",
+      "columns": [
+        {
+          "name": "id",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "bigInt"
+            },
+            "dbHint": null,
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "autoIncrement"
+          }
+        },
+        {
+          "name": "name",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "varChar",
+              "length": 200
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": null
+        },
+        {
+          "name": "userId",
+          "dbName": "user_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "sessionId",
+          "dbName": "session_id",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "uuid"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "payload",
+          "dbName": null,
+          "type": {
+            "scalar": {
+              "kind": "json"
+            },
+            "dbHint": {
+              "kind": "custom",
+              "type_expr": "JsonB"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "literal",
+            "value": {
+              "kind": "string",
+              "value": "{}"
+            }
+          }
+        },
+        {
+          "name": "ipAddr",
+          "dbName": "ip_addr",
+          "type": {
+            "scalar": {
+              "kind": "string"
+            },
+            "dbHint": {
+              "kind": "inet"
+            },
+            "array": false
+          },
+          "nullable": true,
+          "default": null
+        },
+        {
+          "name": "happenedAt",
+          "dbName": "happened_at",
+          "type": {
+            "scalar": {
+              "kind": "timestamp",
+              "precision": 3,
+              "with_timezone": false
+            },
+            "dbHint": {
+              "kind": "timestamptz"
+            },
+            "array": false
+          },
+          "nullable": false,
+          "default": {
+            "kind": "function",
+            "value": "now"
+          }
+        }
+      ],
+      "primaryKey": {
+        "name": null,
+        "columns": [
+          "id"
+        ]
+      },
+      "indexes": [
+        {
+          "name": null,
+          "columns": [
+            {
+              "column": "name",
+              "sort": "asc",
+              "nulls": null
+            },
+            {
+              "column": "happenedAt",
+              "sort": "desc",
+              "nulls": null
+            }
+          ],
+          "unique": false,
+          "partial": null,
+          "indexType": null,
+          "include": []
+        }
+      ],
+      "uniqueConstraints": [],
+      "checkConstraints": [],
+      "foreignKeys": [],
+      "relations": [],
+      "inheritance": null,
+      "behaviors": [],
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": [
+          {
+            "name": "prisma.ignore",
+            "value": true,
+            "recoverable": true
+          }
+        ]
+      }
+    }
+  ],
+  "views": [
+    {
+      "name": "UserStats",
+      "dbName": "v_user_stats",
+      "dbSchema": "analytics",
+      "definition": "",
+      "columns": [
+        {
+          "name": "userId",
+          "dbName": "user_id"
+        },
+        {
+          "name": "email",
+          "dbName": null
+        },
+        {
+          "name": "postCount",
+          "dbName": "post_count"
+        },
+        {
+          "name": "commentCount",
+          "dbName": "comment_count"
+        },
+        {
+          "name": "orderCount",
+          "dbName": "order_count"
+        }
+      ],
+      "updatable": false,
+      "metadata": {
+        "sourceOrm": "prisma",
+        "targetHints": {},
+        "unknownFeatures": []
+      }
+    }
+  ],
+  "materializedViews": [],
+  "enums": [
+    {
+      "name": "Role",
+      "dbName": null,
+      "dbSchema": "public",
+      "values": [
+        {
+          "name": "USER",
+          "dbName": null
+        },
+        {
+          "name": "MODERATOR",
+          "dbName": "moderator"
+        },
+        {
+          "name": "ADMIN",
+          "dbName": "admin"
+        }
+      ]
+    },
+    {
+      "name": "PostStatus",
+      "dbName": "post_status",
+      "dbSchema": "public",
+      "values": [
+        {
+          "name": "DRAFT",
+          "dbName": null
+        },
+        {
+          "name": "PUBLISHED",
+          "dbName": null
+        },
+        {
+          "name": "ARCHIVED",
+          "dbName": null
+        }
+      ]
+    },
+    {
+      "name": "OrderStatus",
+      "dbName": "order_status",
+      "dbSchema": "shop",
+      "values": [
+        {
+          "name": "PENDING",
+          "dbName": null
+        },
+        {
+          "name": "PAID",
+          "dbName": null
+        },
+        {
+          "name": "SHIPPED",
+          "dbName": null
+        },
+        {
+          "name": "DELIVERED",
+          "dbName": null
+        },
+        {
+          "name": "CANCELLED",
+          "dbName": null
+        }
+      ]
+    }
+  ],
+  "compositeTypes": [],
+  "sequences": [],
+  "functions": [],
+  "procedures": [],
+  "triggers": []
+}

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -1,0 +1,31 @@
+use crate::pivot::Schema;
+
+/// Contract that every ORM exporter must satisfy.
+pub trait Exporter {
+    /// Serialize a pivot [`Schema`] into the target ORM's schema format.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError`] if the schema cannot be represented in the target format.
+    fn export(&self, schema: &Schema) -> Result<String, ExportError>;
+}
+
+/// Error returned by any exporter when serializing a schema fails.
+#[derive(Debug)]
+pub enum ExportError {
+    /// The pivot schema contains a construct that has no equivalent in the target ORM.
+    Unsupported(String),
+    /// Serialization failed for an internal reason.
+    Render(String),
+}
+
+impl std::fmt::Display for ExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportError::Unsupported(s) => write!(f, "unsupported construct: {}", s),
+            ExportError::Render(s) => write!(f, "render error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for ExportError {}

--- a/src/importer/mod.rs
+++ b/src/importer/mod.rs
@@ -1,5 +1,17 @@
 pub mod prisma;
 
+use crate::pivot::Schema;
+
+/// Contract that every ORM importer must satisfy.
+pub trait Importer {
+    /// Parse an ORM schema string and return the pivot [`Schema`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] if the input cannot be parsed or is structurally invalid.
+    fn import(&self, input: &str) -> Result<Schema, ImportError>;
+}
+
 /// Error returned by any importer when parsing or resolving a schema fails.
 #[derive(Debug)]
 pub enum ImportError {

--- a/src/importer/mod.rs
+++ b/src/importer/mod.rs
@@ -1,0 +1,21 @@
+pub mod prisma;
+
+/// Error returned by any importer when parsing or resolving a schema fails.
+#[derive(Debug)]
+pub enum ImportError {
+    /// The source file could not be parsed — contains a human-readable description.
+    Parse(String),
+    /// The parsed structure is semantically invalid (e.g. unknown type reference).
+    Schema(String),
+}
+
+impl std::fmt::Display for ImportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImportError::Parse(s) => write!(f, "parse error: {}", s),
+            ImportError::Schema(s) => write!(f, "schema error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for ImportError {}

--- a/src/importer/prisma/ast.rs
+++ b/src/importer/prisma/ast.rs
@@ -1,0 +1,122 @@
+// Raw intermediate types produced by the PEG parser (Phase 1).
+// These are internal to the prisma importer — never exposed publicly.
+
+#[derive(Debug)]
+pub(super) struct RawAttr {
+    pub(super) path: String,
+    pub(super) args: Vec<RawArg>,
+}
+
+impl RawAttr {
+    pub(super) fn named(&self, key: &str) -> Option<&RawValue> {
+        self.args.iter().find_map(|a| match a {
+            RawArg::Named(k, v) if k == key => Some(v),
+            _ => None,
+        })
+    }
+
+    pub(super) fn positional(&self, idx: usize) -> Option<&RawValue> {
+        self.args
+            .iter()
+            .filter_map(|a| match a {
+                RawArg::Positional(v) => Some(v),
+                _ => None,
+            })
+            .nth(idx)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum RawArg {
+    Named(String, RawValue),
+    Positional(RawValue),
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum RawValue {
+    Str(String),
+    Int(i64),
+    Float(f64),
+    Ident(String),
+    Array(Vec<RawValue>),
+    /// A function call — args use [`RawArg`] so named args (`sort: Desc`) are preserved.
+    Call(String, Vec<RawArg>),
+}
+
+impl RawValue {
+    pub(super) fn as_str(&self) -> Option<&str> {
+        match self {
+            RawValue::Str(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_int(&self) -> Option<i64> {
+        match self {
+            RawValue::Int(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_ident(&self) -> Option<&str> {
+        match self {
+            RawValue::Ident(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_string_array(&self) -> Vec<String> {
+        match self {
+            RawValue::Array(items) => items
+                .iter()
+                .filter_map(|v| v.as_ident().or_else(|| v.as_str()).map(String::from))
+                .collect(),
+            _ => vec![],
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct RawField {
+    pub(super) name: String,
+    /// Set when the field type is `Unsupported("...")`.
+    pub(super) unsupported_type: Option<String>,
+    pub(super) base_type: String,
+    pub(super) is_optional: bool,
+    pub(super) is_array: bool,
+    pub(super) attrs: Vec<RawAttr>,
+}
+
+impl RawField {
+    pub(super) fn attr(&self, path: &str) -> Option<&RawAttr> {
+        self.attrs.iter().find(|a| a.path == path)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct RawModel {
+    pub(super) name: String,
+    pub(super) fields: Vec<RawField>,
+    pub(super) block_attrs: Vec<RawAttr>,
+}
+
+impl RawModel {
+    pub(super) fn block_attr(&self, path: &str) -> Option<&RawAttr> {
+        self.block_attrs.iter().find(|a| a.path == path)
+    }
+
+    pub(super) fn block_attrs_all<'a>(
+        &'a self,
+        path: &'a str,
+    ) -> impl Iterator<Item = &'a RawAttr> {
+        self.block_attrs.iter().filter(move |a| a.path == path)
+    }
+}
+
+/// A Prisma `type` alias — a scalar type with optional default attributes.
+#[derive(Debug)]
+pub(super) struct RawTypeAlias {
+    pub(super) name: String,
+    pub(super) base_type: String,
+    pub(super) attrs: Vec<RawAttr>,
+}

--- a/src/importer/prisma/grammar.pest
+++ b/src/importer/prisma/grammar.pest
@@ -1,0 +1,76 @@
+// ── Silent rules (auto-consumed between tokens) ────────────────────────────
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
+COMMENT    = _{ ("///" | "//") ~ (!"\n" ~ ANY)* }
+
+// ── Primitives ─────────────────────────────────────────────────────────────
+identifier  = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
+string_lit   = ${ "\"" ~ string_inner ~ "\"" }
+string_inner = @{ (escape_seq | (!"\"" ~ ANY))* }
+escape_seq   = @{ "\\" ~ ("\"" | "\\" | "n" | "r" | "t" | "u") }
+integer     = @{ "-"? ~ ASCII_DIGIT+ }
+float_num   = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
+
+// ── Top-level ──────────────────────────────────────────────────────────────
+schema = { SOI ~ block* ~ EOI }
+
+block = {
+    datasource_block
+  | generator_block
+  | model_block
+  | enum_block
+  | view_block
+  | type_alias
+}
+
+// ── Config blocks (datasource / generator) ─────────────────────────────────
+datasource_block = { "datasource" ~ identifier ~ "{" ~ config_field* ~ "}" }
+generator_block  = { "generator"  ~ identifier ~ "{" ~ config_field* ~ "}" }
+config_field     = { identifier ~ "=" ~ config_value }
+config_value     = { env_func | array_value | string_lit | identifier }
+env_func         = { "env" ~ "(" ~ string_lit ~ ")" }
+
+// ── Model block ────────────────────────────────────────────────────────────
+model_block = { "model" ~ identifier ~ "{" ~ model_entry* ~ "}" }
+model_entry = { block_attribute | field_decl }
+
+field_decl       = { identifier ~ field_type ~ field_attribute* }
+field_type       = { unsupported_type | scalar_field_type }
+scalar_field_type = { base_type ~ type_modifier? }
+unsupported_type = { "Unsupported" ~ "(" ~ string_lit ~ ")" ~ type_modifier? }
+base_type        = @{ identifier }
+type_modifier    = { "[]" | "?" }
+
+// ── Attributes ─────────────────────────────────────────────────────────────
+field_attribute = { "@" ~ attribute_path ~ attribute_args? }
+block_attribute = { "@@" ~ attribute_path ~ attribute_args? }
+attribute_path  = @{ identifier ~ ("." ~ identifier)* }
+attribute_args  = { "(" ~ arg_list? ~ ")" }
+arg_list        = { argument ~ ("," ~ argument)* ~ ","? }
+argument        = { named_arg | positional_arg }
+named_arg       = { identifier ~ ":" ~ attr_value }
+positional_arg  = { attr_value }
+
+// function_call must come before identifier so "uuid()" is not parsed as just "uuid"
+attr_value = {
+    array_value
+  | function_call
+  | string_lit
+  | float_num
+  | integer
+  | identifier
+}
+
+array_value   = { "[" ~ (attr_value ~ ("," ~ attr_value)* ~ ","?)? ~ "]" }
+// function_call uses arg_list so `field(sort: Desc)` can carry named args (e.g. @@index columns)
+function_call = { identifier ~ "(" ~ arg_list? ~ ")" }
+
+// ── Enum block ─────────────────────────────────────────────────────────────
+enum_block  = { "enum" ~ identifier ~ "{" ~ enum_entry* ~ "}" }
+enum_entry  = { block_attribute | enum_value }
+enum_value  = { identifier ~ field_attribute* }
+
+// ── View block (Prisma 4.9+) — parsed but stored in OrmMetadata ───────────
+view_block = { "view" ~ identifier ~ "{" ~ model_entry* ~ "}" }
+
+// ── Type alias — parsed but inlined at use site ───────────────────────────
+type_alias = { "type" ~ identifier ~ "=" ~ base_type ~ field_attribute* }

--- a/src/importer/prisma/mappers.rs
+++ b/src/importer/prisma/mappers.rs
@@ -1,0 +1,313 @@
+use super::ast::{RawArg, RawAttr, RawModel, RawValue};
+use crate::pivot::relation::ReferentialAction;
+use crate::pivot::table::{IndexColumn, IndexType, SortDirection};
+use crate::pivot::types::{DbHint, DefaultFn, DefaultValue, LiteralValue, ScalarType};
+
+// ── Duplication helpers ────────────────────────────────────────────────────
+
+/// Extracts `db_name` (from `@@map`) and `db_schema` (from `@@schema`) from a raw model's
+/// block attributes.
+pub(super) fn extract_db_naming(raw: &RawModel) -> (Option<String>, Option<String>) {
+    let db_name = raw
+        .block_attr("map")
+        .and_then(|a| a.positional(0))
+        .and_then(|v| v.as_str().map(String::from));
+    let db_schema = raw
+        .block_attr("schema")
+        .and_then(|a| a.positional(0))
+        .and_then(|v| v.as_str().map(String::from));
+    (db_name, db_schema)
+}
+
+/// Extracts a column list from `named("fields")` or `positional(0)`.
+///
+/// Used for `@@index`, `@@unique`, `@@id` and similar multi-column attributes.
+pub(super) fn extract_columns_from_attr(attr: &RawAttr) -> Vec<String> {
+    attr.named("fields")
+        .or_else(|| attr.positional(0))
+        .map(RawValue::as_string_array)
+        .unwrap_or_default()
+}
+
+// ── Index helpers ──────────────────────────────────────────────────────────
+
+/// Parse an index column descriptor from a Prisma attribute value.
+///
+/// Handles both a plain identifier (`email`) and a function-call form
+/// (`email(sort: Desc)`) produced by `@@index([email(sort: Desc)])`.
+pub(super) fn extract_one_index_col(v: &RawValue) -> IndexColumn {
+    match v {
+        RawValue::Ident(name) => IndexColumn {
+            column: name.clone(),
+            sort: SortDirection::Asc,
+            nulls: None,
+        },
+        RawValue::Call(name, args) => {
+            let sort = args
+                .iter()
+                .find_map(|a| match a {
+                    RawArg::Named(k, v) if k == "sort" => v.as_ident().map(|s| match s {
+                        "Desc" => SortDirection::Desc,
+                        _ => SortDirection::Asc,
+                    }),
+                    _ => None,
+                })
+                .unwrap_or(SortDirection::Asc);
+            IndexColumn {
+                column: name.clone(),
+                sort,
+                nulls: None,
+            }
+        }
+        _ => IndexColumn {
+            column: String::new(),
+            sort: SortDirection::Asc,
+            nulls: None,
+        },
+    }
+}
+
+pub(super) fn extract_index_columns(v: &RawValue) -> Vec<IndexColumn> {
+    match v {
+        RawValue::Array(items) => items.iter().map(extract_one_index_col).collect(),
+        other => vec![extract_one_index_col(other)],
+    }
+}
+
+pub(super) fn map_index_type(s: &str) -> IndexType {
+    match s {
+        "BTree" | "Btree" => IndexType::BTree,
+        "Hash" => IndexType::Hash,
+        "Gin" => IndexType::Gin,
+        "Gist" => IndexType::Gist,
+        "Brin" => IndexType::Brin,
+        "SpGist" => IndexType::SpGist,
+        other => IndexType::Custom {
+            name: other.to_string(),
+        },
+    }
+}
+
+// ── Type mapping helpers ───────────────────────────────────────────────────
+
+pub(super) fn map_scalar_type(prisma_type: &str) -> Option<ScalarType> {
+    Some(match prisma_type {
+        "String" => ScalarType::String,
+        "Int" => ScalarType::Int,
+        "BigInt" => ScalarType::BigInt,
+        // Prisma Float is 64-bit (equivalent to Double in our IR)
+        "Float" => ScalarType::Double,
+        "Decimal" => ScalarType::Decimal {
+            precision: 65,
+            scale: 30,
+        },
+        "Boolean" => ScalarType::Boolean,
+        "DateTime" => ScalarType::Timestamp {
+            precision: 3,
+            with_timezone: false,
+        },
+        "Json" => ScalarType::Json,
+        "Bytes" => ScalarType::Bytes,
+        _ => return None,
+    })
+}
+
+pub(super) fn map_db_hint(path: &str, args: &[RawArg]) -> Option<DbHint> {
+    let hint = path.strip_prefix("db.")?;
+
+    // Helper: first positional int argument.
+    let first_int = || -> Option<i64> {
+        args.iter().find_map(|a| match a {
+            RawArg::Positional(v) => v.as_int(),
+            RawArg::Named(_, v) => v.as_int(),
+        })
+    };
+
+    // Helper: two positional ints (precision, scale) with named-arg fallback.
+    let two_ints = || -> (Option<u8>, Option<u8>) {
+        let named_p = args.iter().find_map(|a| match a {
+            RawArg::Named(k, v) if k == "precision" => v.as_int().map(|n| n as u8),
+            _ => None,
+        });
+        let named_s = args.iter().find_map(|a| match a {
+            RawArg::Named(k, v) if k == "scale" => v.as_int().map(|n| n as u8),
+            _ => None,
+        });
+        let mut pos = args.iter().filter_map(|a| match a {
+            RawArg::Positional(v) => v.as_int().map(|n| n as u8),
+            _ => None,
+        });
+        let p = named_p.or_else(|| pos.next());
+        let s = named_s.or_else(|| pos.next());
+        (p, s)
+    };
+
+    // Helper: optional precision arg (defaults to 0 when omitted, e.g. `@db.Time`).
+    let precision = || first_int().unwrap_or(0) as u8;
+
+    Some(match hint {
+        // ── String ───────────────────────────────────────────────────────
+        "VarChar" => DbHint::VarChar {
+            length: first_int()? as u32,
+        },
+        "Char" => DbHint::Char {
+            length: first_int()? as u32,
+        },
+        "Text" => DbHint::Text,
+        "TinyText" => DbHint::TinyText,
+        "MediumText" => DbHint::MediumText,
+        "LongText" => DbHint::LongText,
+        // ── Integer ──────────────────────────────────────────────────────
+        "SmallInt" => DbHint::SmallInt,
+        "Int" | "Integer" => DbHint::Int,
+        "BigInt" => DbHint::BigInt,
+        "TinyInt" => DbHint::TinyInt,
+        "MediumInt" => DbHint::MediumInt,
+        "Year" => DbHint::Year,
+        // ── Float ────────────────────────────────────────────────────────
+        "Float" => DbHint::Float,
+        "DoublePrecision" => DbHint::DoublePrecision,
+        "Real" => DbHint::Real,
+        "Decimal" | "Numeric" => {
+            let (p, s) = two_ints();
+            DbHint::Numeric {
+                precision: p?,
+                scale: s?,
+            }
+        }
+        // ── Binary / blob ─────────────────────────────────────────────────
+        "VarBinary" => DbHint::VarBinary {
+            length: first_int()? as u32,
+        },
+        "Binary" => DbHint::Binary {
+            length: first_int()? as u32,
+        },
+        "TinyBlob" => DbHint::TinyBlob,
+        "Blob" => DbHint::Blob,
+        "MediumBlob" => DbHint::MediumBlob,
+        "LongBlob" => DbHint::LongBlob,
+        "ByteA" => DbHint::ByteA,
+        "Bit" | "VarBit" => DbHint::Bit {
+            length: first_int().map(|n| n as u32),
+        },
+        // ── Date / time ──────────────────────────────────────────────────
+        "Date" => DbHint::Date,
+        "Time" => DbHint::Time {
+            precision: precision(),
+        },
+        "DateTime" => DbHint::DateTime {
+            precision: precision(),
+        },
+        "Timestamp" => DbHint::Timestamp {
+            precision: precision(),
+        },
+        "Timestamptz" => DbHint::Timestamptz,
+        "Timetz" => DbHint::Timetz,
+        "Interval" => DbHint::Interval,
+        // ── PostgreSQL-specific ───────────────────────────────────────────
+        "Uuid" => DbHint::Uuid,
+        "Inet" => DbHint::Inet,
+        "Cidr" => DbHint::Cidr,
+        "Xml" => DbHint::Xml,
+        "Money" => DbHint::Money,
+        "Oid" => DbHint::Oid,
+        other => DbHint::Custom {
+            type_expr: other.to_string(),
+        },
+    })
+}
+
+pub(super) fn map_default_value(v: &RawValue) -> Option<DefaultValue> {
+    match v {
+        RawValue::Str(s) => Some(DefaultValue::Literal(LiteralValue::String(s.clone()))),
+        RawValue::Int(n) => Some(DefaultValue::Literal(LiteralValue::Int(*n))),
+        RawValue::Float(f) => Some(DefaultValue::Literal(LiteralValue::Float(*f))),
+        RawValue::Ident(s) => match s.as_str() {
+            "true" => Some(DefaultValue::Literal(LiteralValue::Bool(true))),
+            "false" => Some(DefaultValue::Literal(LiteralValue::Bool(false))),
+            other => Some(DefaultValue::Literal(LiteralValue::String(
+                other.to_string(),
+            ))),
+        },
+        RawValue::Call(name, args) => match name.as_str() {
+            "autoincrement" => Some(DefaultValue::Function(DefaultFn::AutoIncrement)),
+            "now" => Some(DefaultValue::Function(DefaultFn::Now)),
+            "uuid" => Some(DefaultValue::Function(DefaultFn::Uuid)),
+            "cuid" => Some(DefaultValue::Function(DefaultFn::Cuid)),
+            "cuid2" => Some(DefaultValue::Function(DefaultFn::Cuid2)),
+            "ulid" => Some(DefaultValue::Function(DefaultFn::Ulid)),
+            "dbgenerated" => {
+                let expr = args
+                    .iter()
+                    .find_map(|a| match a {
+                        RawArg::Positional(v) => v.as_str().map(String::from),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                Some(DefaultValue::Raw(expr))
+            }
+            _ => None,
+        },
+        RawValue::Array(_) => None,
+    }
+}
+
+pub(super) fn parse_referential_action(s: &str) -> Option<ReferentialAction> {
+    Some(match s {
+        "Cascade" => ReferentialAction::Cascade,
+        "Restrict" => ReferentialAction::Restrict,
+        "SetNull" => ReferentialAction::SetNull,
+        "SetDefault" => ReferentialAction::SetDefault,
+        "NoAction" => ReferentialAction::NoAction,
+        _ => return None,
+    })
+}
+
+// ── Unknown attribute helpers ──────────────────────────────────────────────
+
+pub(super) fn raw_value_to_json(v: &RawValue) -> serde_json::Value {
+    match v {
+        RawValue::Str(s) => serde_json::Value::String(s.clone()),
+        RawValue::Int(n) => serde_json::json!(n),
+        RawValue::Float(f) => serde_json::json!(f),
+        RawValue::Ident(s) => serde_json::Value::String(s.clone()),
+        RawValue::Array(items) => {
+            serde_json::Value::Array(items.iter().map(raw_value_to_json).collect())
+        }
+        RawValue::Call(name, args) => serde_json::json!({
+            "fn": name,
+            "args": args.iter().map(|a| match a {
+                RawArg::Named(k, v)   => serde_json::json!({ k: raw_value_to_json(v) }),
+                RawArg::Positional(v) => raw_value_to_json(v),
+            }).collect::<Vec<_>>(),
+        }),
+    }
+}
+
+pub(super) fn raw_args_to_json(args: &[RawArg]) -> serde_json::Value {
+    if args.is_empty() {
+        return serde_json::Value::Bool(true);
+    }
+    let positional: Vec<serde_json::Value> = args
+        .iter()
+        .filter_map(|a| match a {
+            RawArg::Positional(v) => Some(raw_value_to_json(v)),
+            _ => None,
+        })
+        .collect();
+    if positional.len() == 1 && args.iter().all(|a| matches!(a, RawArg::Positional(_))) {
+        return positional.into_iter().next().unwrap();
+    }
+    let mut obj = serde_json::Map::new();
+    for arg in args {
+        match arg {
+            RawArg::Named(k, v) => {
+                obj.insert(k.clone(), raw_value_to_json(v));
+            }
+            RawArg::Positional(v) => {
+                obj.insert("_".to_string(), raw_value_to_json(v));
+            }
+        }
+    }
+    serde_json::Value::Object(obj)
+}

--- a/src/importer/prisma/mod.rs
+++ b/src/importer/prisma/mod.rs
@@ -1,0 +1,790 @@
+use std::collections::{HashMap, HashSet};
+
+use pest::Parser;
+
+use crate::pivot::{DatabaseKind, Enum, Schema};
+
+mod ast;
+mod mappers;
+mod parser;
+mod resolver;
+use ast::{RawModel, RawTypeAlias};
+use parser::{PrismaParser, Rule};
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/// Parse a Prisma Schema Language string and return the pivot [`Schema`].
+///
+/// # Errors
+///
+/// Returns [`ImportError::Parse`] if the input is not valid PSL, or
+/// [`ImportError::Schema`] if the schema is structurally invalid (e.g. a
+/// field references a model that does not exist).
+///
+/// # Examples
+///
+/// ```
+/// use transf_orm_cli::importer::prisma::parse_schema;
+///
+/// let input = r#"
+///   datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+///   model User {
+///     id    Int    @id @default(autoincrement())
+///     email String @unique
+///   }
+/// "#;
+///
+/// let schema = parse_schema(input).unwrap();
+/// assert_eq!(schema.tables.len(), 1);
+/// assert_eq!(schema.tables[0].name, "User");
+/// ```
+pub fn parse_schema(input: &str) -> Result<Schema, super::ImportError> {
+    let pairs = PrismaParser::parse(Rule::schema, input)?;
+    let schema_pair = pairs.into_iter().next().unwrap();
+
+    let mut database = DatabaseKind::PostgreSql;
+    let mut raw_models: Vec<RawModel> = Vec::new();
+    let mut raw_views: Vec<RawModel> = Vec::new();
+    let mut enums: Vec<Enum> = Vec::new();
+    let mut type_aliases: HashMap<String, RawTypeAlias> = HashMap::new();
+
+    for pair in schema_pair.into_inner() {
+        match pair.as_rule() {
+            Rule::block => {
+                let inner = pair.into_inner().next().unwrap();
+                match inner.as_rule() {
+                    Rule::datasource_block => database = parser::extract_database_kind(inner),
+                    Rule::model_block => raw_models.push(parser::parse_model_block(inner)?),
+                    Rule::view_block => raw_views.push(parser::parse_model_block(inner)?),
+                    Rule::enum_block => enums.push(parser::parse_enum_block(inner)?),
+                    Rule::type_alias => {
+                        let alias = parser::parse_type_alias(inner)?;
+                        type_aliases.insert(alias.name.clone(), alias);
+                    }
+                    _ => {} // generator_block
+                }
+            }
+            Rule::EOI => {}
+            _ => {}
+        }
+    }
+
+    let model_names: HashSet<String> = raw_models.iter().map(|m| m.name.clone()).collect();
+    let enum_names: HashSet<String> = enums.iter().map(|e| e.name.clone()).collect();
+    let tables = resolver::resolve_models(raw_models, &model_names, &enum_names, &type_aliases)?;
+    let views = resolver::resolve_views(raw_views, &enum_names, &type_aliases)?;
+
+    let mut schema = Schema::new(database);
+    schema.tables = tables;
+    schema.enums = enums;
+    schema.views = views;
+    Ok(schema)
+}
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pivot::metadata::OrmKind;
+    use crate::pivot::relation::{ReferentialAction, RelationKind};
+    use crate::pivot::table::{Behavior, IndexType, SortDirection};
+    use crate::pivot::types::{DbHint, DefaultFn, DefaultValue, LiteralValue, ScalarType};
+
+    const SCHEMA: &str = r#"
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        model User {
+          id        Int      @id @default(autoincrement())
+          email     String   @unique @db.VarChar(255)
+          name      String?
+          role      Role     @default(USER)
+          posts     Post[]
+          updatedAt DateTime @updatedAt @map("updated_at")
+
+          @@map("users")
+        }
+
+        model Post {
+          id        Int     @id @default(autoincrement())
+          title     String  @db.VarChar(255)
+          content   String?
+          published Boolean @default(false)
+          authorId  Int
+          author    User    @relation(fields: [authorId], references: [id], onDelete: Cascade)
+          tags      Tag[]
+
+          @@index([title])
+          @@map("posts")
+        }
+
+        model Tag {
+          id    Int    @id @default(autoincrement())
+          name  String @unique
+          posts Post[]
+
+          @@map("tags")
+        }
+
+        enum Role {
+          USER
+          ADMIN @map("admin")
+        }
+    "#;
+
+    #[test]
+    fn detects_postgresql_database() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        assert_eq!(schema.database, DatabaseKind::PostgreSql);
+    }
+
+    #[test]
+    fn parses_three_tables() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        assert_eq!(schema.tables.len(), 3);
+        assert_eq!(schema.tables[0].name, "User");
+        assert_eq!(schema.tables[1].name, "Post");
+        assert_eq!(schema.tables[2].name, "Tag");
+    }
+
+    #[test]
+    fn maps_table_db_names() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        assert_eq!(schema.tables[0].db_name.as_deref(), Some("users"));
+        assert_eq!(schema.tables[1].db_name.as_deref(), Some("posts"));
+    }
+
+    #[test]
+    fn user_primary_key_and_default() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let user = &schema.tables[0];
+        let pk = user.primary_key.as_ref().unwrap();
+        assert_eq!(pk.columns, ["id"]);
+        let id_col = user.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(
+            id_col.default,
+            Some(DefaultValue::Function(DefaultFn::AutoIncrement))
+        );
+        assert!(!id_col.nullable);
+    }
+
+    #[test]
+    fn varchar_db_hint_preserved() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let user = &schema.tables[0];
+        let email = user.columns.iter().find(|c| c.name == "email").unwrap();
+        assert_eq!(
+            email.col_type.db_hint,
+            Some(DbHint::VarChar { length: 255 })
+        );
+    }
+
+    #[test]
+    fn nullable_and_unique() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let user = &schema.tables[0];
+        let name_col = user.columns.iter().find(|c| c.name == "name").unwrap();
+        assert!(name_col.nullable);
+        assert!(user
+            .unique_constraints
+            .iter()
+            .any(|u| u.columns == ["email"]));
+    }
+
+    #[test]
+    fn enum_column_and_default() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let user = &schema.tables[0];
+        let role = user.columns.iter().find(|c| c.name == "role").unwrap();
+        assert_eq!(
+            role.col_type.scalar,
+            ScalarType::Enum {
+                name: "Role".to_string()
+            }
+        );
+        assert_eq!(
+            role.default,
+            Some(DefaultValue::Literal(LiteralValue::String(
+                "USER".to_string()
+            )))
+        );
+    }
+
+    #[test]
+    fn updated_at_behavior() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let user = &schema.tables[0];
+        assert!(user
+            .behaviors
+            .iter()
+            .any(|b| matches!(b, Behavior::UpdatedAt { column } if column == "updatedAt")));
+    }
+
+    #[test]
+    fn post_has_foreign_key_and_index() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let post = &schema.tables[1];
+        let fk = post
+            .foreign_keys
+            .iter()
+            .find(|fk| fk.referenced_table == "User")
+            .unwrap();
+        assert_eq!(fk.columns, ["authorId"]);
+        assert_eq!(fk.referenced_columns, ["id"]);
+        assert_eq!(fk.on_delete, Some(ReferentialAction::Cascade));
+        assert!(post
+            .indexes
+            .iter()
+            .any(|i| i.columns.iter().any(|c| c.column == "title")));
+    }
+
+    #[test]
+    fn implicit_m2m_post_tag() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        let post = &schema.tables[1];
+        let m2m = post
+            .relations
+            .iter()
+            .find(|r| matches!(&r.kind, RelationKind::ManyToMany { implicit, .. } if *implicit));
+        assert!(m2m.is_some(), "Post should have an implicit M2M relation");
+    }
+
+    #[test]
+    fn enum_values_parsed() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        assert_eq!(schema.enums.len(), 1);
+        let role = &schema.enums[0];
+        assert_eq!(role.name, "Role");
+        assert_eq!(role.values[0].name, "USER");
+        assert_eq!(role.values[1].name, "ADMIN");
+        assert_eq!(role.values[1].db_name.as_deref(), Some("admin"));
+    }
+
+    #[test]
+    fn source_orm_is_prisma() {
+        let schema = parse_schema(SCHEMA).unwrap();
+        assert_eq!(schema.tables[0].metadata.source_orm, Some(OrmKind::Prisma));
+    }
+
+    #[test]
+    fn scalar_array_field_sets_array_flag() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Post {
+              id   Int      @id
+              tags String[]
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let post = &schema.tables[0];
+        let tags = post.columns.iter().find(|c| c.name == "tags").unwrap();
+        assert!(tags.col_type.array, "String[] should set array: true");
+    }
+
+    #[test]
+    fn db_schema_attribute() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Analytics {
+              id Int @id
+              @@schema("analytics")
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        assert_eq!(schema.tables[0].db_schema.as_deref(), Some("analytics"));
+    }
+
+    #[test]
+    fn model_ignore_stored_in_metadata() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Legacy {
+              id Int @id
+              @@ignore
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let table = &schema.tables[0];
+        let feat = table
+            .metadata
+            .unknown_features
+            .iter()
+            .find(|f| f.name == "prisma.ignore");
+        assert!(
+            feat.is_some(),
+            "@@ignore should produce unknown_feature 'prisma.ignore'"
+        );
+        assert_eq!(feat.unwrap().value, serde_json::json!(true));
+    }
+
+    #[test]
+    fn field_ignore_stored_in_metadata() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model User {
+              id     Int    @id
+              secret String @ignore
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let table = &schema.tables[0];
+        let feat = table
+            .metadata
+            .unknown_features
+            .iter()
+            .find(|f| f.name == "prisma.ignoredFields");
+        assert!(feat.is_some());
+        assert_eq!(feat.unwrap().value, serde_json::json!(["secret"]));
+        // Column is still present (it exists in the DB)
+        assert!(table.columns.iter().any(|c| c.name == "secret"));
+    }
+
+    #[test]
+    fn db_decimal_two_args() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Order {
+              id    Int     @id
+              price Decimal @db.Decimal(10, 2)
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let col = schema.tables[0]
+            .columns
+            .iter()
+            .find(|c| c.name == "price")
+            .unwrap();
+        assert_eq!(
+            col.col_type.db_hint,
+            Some(DbHint::Numeric {
+                precision: 10,
+                scale: 2
+            })
+        );
+    }
+
+    #[test]
+    fn type_alias_inlined() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            type PostId = Int @id @default(autoincrement())
+            model Post {
+              id PostId
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let post = &schema.tables[0];
+        let id_col = post.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id_col.col_type.scalar, ScalarType::Int);
+        assert_eq!(
+            id_col.default,
+            Some(DefaultValue::Function(DefaultFn::AutoIncrement))
+        );
+        assert!(post
+            .primary_key
+            .as_ref()
+            .map(|pk| pk.columns.contains(&"id".to_string()))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn view_block_parsed() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            view UserView {
+              id    Int
+              email String
+              @@map("v_users")
+              @@schema("reporting")
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        assert_eq!(schema.views.len(), 1);
+        let view = &schema.views[0];
+        assert_eq!(view.name, "UserView");
+        assert_eq!(view.db_name.as_deref(), Some("v_users"));
+        assert_eq!(view.db_schema.as_deref(), Some("reporting"));
+        assert_eq!(view.columns.len(), 2);
+        assert_eq!(view.columns[0].name, "id");
+        assert!(!view.updatable);
+    }
+
+    #[test]
+    fn index_with_sort_and_type() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Post {
+              id    Int    @id
+              title String
+              body  String
+              @@index([title(sort: Asc), body(sort: Desc)], type: Hash)
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let idx = &schema.tables[0].indexes[0];
+        assert_eq!(idx.columns[0].sort, SortDirection::Asc);
+        assert_eq!(idx.columns[1].sort, SortDirection::Desc);
+        assert!(matches!(idx.index_type, Some(IndexType::Hash)));
+    }
+
+    #[test]
+    fn index_constraint_names() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model User {
+              id    Int    @id(map: "pk_user")
+              email String
+              name  String
+              @@unique(fields: [email, name], map: "uq_user_email_name")
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let table = &schema.tables[0];
+        assert_eq!(
+            table.primary_key.as_ref().unwrap().name.as_deref(),
+            Some("pk_user")
+        );
+        let uq = table
+            .unique_constraints
+            .iter()
+            .find(|u| u.columns.contains(&"email".to_string()))
+            .unwrap();
+        assert_eq!(uq.name.as_deref(), Some("uq_user_email_name"));
+    }
+
+    #[test]
+    fn fulltext_index() {
+        let input = r#"
+            datasource db { provider = "mysql" url = env("DATABASE_URL") }
+            model Post {
+              id    Int    @id
+              title String
+              body  String
+              @@fulltext([title, body])
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let idx = schema.tables[0].indexes.iter().find(
+            |i| matches!(&i.index_type, Some(IndexType::Custom { name }) if name == "fulltext"),
+        );
+        assert!(
+            idx.is_some(),
+            "@@fulltext should produce a 'fulltext' index"
+        );
+        assert_eq!(idx.unwrap().columns.len(), 2);
+    }
+
+    #[test]
+    fn db_type_hints_uuid_and_date() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Event {
+              id        String   @id @db.Uuid
+              happenedOn DateTime @db.Date
+              startTime DateTime @db.Time(3)
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let cols = &schema.tables[0].columns;
+        let id = cols.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(id.col_type.db_hint, Some(DbHint::Uuid));
+        let date = cols.iter().find(|c| c.name == "happenedOn").unwrap();
+        assert_eq!(date.col_type.db_hint, Some(DbHint::Date));
+        let time = cols.iter().find(|c| c.name == "startTime").unwrap();
+        assert_eq!(time.col_type.db_hint, Some(DbHint::Time { precision: 3 }));
+    }
+
+    #[test]
+    fn parse_full_test_schema() {
+        let input = include_str!("../../../test.prisma");
+        let schema = parse_schema(input).expect("test.prisma should parse without error");
+
+        // Database
+        assert_eq!(schema.database, DatabaseKind::PostgreSql);
+
+        // Tables
+        let table_names: Vec<&str> = schema.tables.iter().map(|t| t.name.as_str()).collect();
+        assert!(table_names.contains(&"User"), "User table missing");
+        assert!(table_names.contains(&"Profile"), "Profile table missing");
+        assert!(table_names.contains(&"Post"), "Post table missing");
+        assert!(table_names.contains(&"Comment"), "Comment table missing");
+        assert!(table_names.contains(&"Tag"), "Tag table missing");
+        assert!(table_names.contains(&"Media"), "Media table missing");
+        assert!(table_names.contains(&"Review"), "Review table missing");
+        assert!(table_names.contains(&"Product"), "Product table missing");
+        assert!(table_names.contains(&"Order"), "Order table missing");
+        assert!(
+            table_names.contains(&"OrderItem"),
+            "OrderItem table missing"
+        );
+        assert!(table_names.contains(&"Event"), "Event table missing");
+
+        // Enums
+        assert_eq!(schema.enums.len(), 3);
+
+        // View
+        assert_eq!(schema.views.len(), 1);
+        assert_eq!(schema.views[0].name, "UserStats");
+
+        // Type alias inlining: User.id should be String/Uuid from UuidPk alias
+        let user = schema.tables.iter().find(|t| t.name == "User").unwrap();
+        let user_id = user.columns.iter().find(|c| c.name == "id").unwrap();
+        assert_eq!(user_id.col_type.scalar, ScalarType::String);
+        assert_eq!(user_id.col_type.db_hint, Some(DbHint::Uuid));
+        assert!(user
+            .primary_key
+            .as_ref()
+            .map(|pk| pk.columns.contains(&"id".to_string()))
+            .unwrap_or(false));
+
+        // @@schema
+        assert_eq!(user.db_schema.as_deref(), Some("public"));
+        let product = schema.tables.iter().find(|t| t.name == "Product").unwrap();
+        assert_eq!(product.db_schema.as_deref(), Some("shop"));
+        let event = schema.tables.iter().find(|t| t.name == "Event").unwrap();
+        assert_eq!(event.db_schema.as_deref(), Some("analytics"));
+
+        // @@ignore on Event
+        assert!(event
+            .metadata
+            .unknown_features
+            .iter()
+            .any(|f| f.name == "prisma.ignore"));
+
+        // @ignore on Post.internalNote — column still present
+        let post = schema.tables.iter().find(|t| t.name == "Post").unwrap();
+        assert!(post.columns.iter().any(|c| c.name == "internalNote"));
+        assert!(post
+            .metadata
+            .unknown_features
+            .iter()
+            .any(|f| f.name == "prisma.ignoredFields"));
+
+        // Post.tags String[] — scalar array
+        let user_tags = user.columns.iter().find(|c| c.name == "tags").unwrap();
+        assert!(user_tags.col_type.array);
+
+        // Implicit M2M Post ↔ Tag
+        assert!(post
+            .relations
+            .iter()
+            .any(|r| matches!(&r.kind, RelationKind::ManyToMany { implicit, .. } if *implicit)));
+
+        // Named relations Review → User (two distinct)
+        let review = schema.tables.iter().find(|t| t.name == "Review").unwrap();
+        assert_eq!(review.foreign_keys.len(), 2);
+
+        // Composite PK on OrderItem
+        let order_item = schema
+            .tables
+            .iter()
+            .find(|t| t.name == "OrderItem")
+            .unwrap();
+        let pk = order_item.primary_key.as_ref().unwrap();
+        assert!(pk.columns.contains(&"orderId".to_string()));
+        assert!(pk.columns.contains(&"productId".to_string()));
+
+        // @@fulltext on Post
+        assert!(post.indexes.iter().any(
+            |i| matches!(&i.index_type, Some(IndexType::Custom { name }) if name == "fulltext")
+        ));
+
+        // @@index with sort on User
+        let user_idx = user
+            .indexes
+            .iter()
+            .find(|i| i.columns.iter().any(|c| c.column == "createdAt"))
+            .unwrap();
+        assert_eq!(user_idx.columns[0].sort, SortDirection::Desc);
+
+        // @db.Decimal(12, 2) on User.balance
+        let balance = user.columns.iter().find(|c| c.name == "balance").unwrap();
+        assert_eq!(
+            balance.col_type.db_hint,
+            Some(DbHint::Numeric {
+                precision: 12,
+                scale: 2
+            })
+        );
+
+        // @db.Inet on User.ipAddress
+        let ip = user.columns.iter().find(|c| c.name == "ipAddress").unwrap();
+        assert_eq!(ip.col_type.db_hint, Some(DbHint::Inet));
+
+        // Unsupported("hstore") on Profile.rawConfig
+        let profile = schema.tables.iter().find(|t| t.name == "Profile").unwrap();
+        let raw_config = profile
+            .columns
+            .iter()
+            .find(|c| c.name == "rawConfig")
+            .unwrap();
+        assert!(
+            matches!(&raw_config.col_type.scalar, ScalarType::Unsupported { type_name } if type_name == "hstore")
+        );
+
+        // Round-trip through JSON
+        let json = schema.to_canonical_json().expect("serialization failed");
+        let restored = crate::pivot::Schema::from_json(&json).expect("deserialization failed");
+        assert_eq!(schema, restored);
+    }
+
+    #[test]
+    fn named_relation_cardinality() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model User {
+              id            Int    @id
+              writtenPosts  Post[] @relation("WrittenPosts")
+              favoritePosts Post[] @relation("FavoritePosts")
+            }
+            model Post {
+              id              Int  @id
+              authorId        Int
+              favoritedById   Int?
+              author          User  @relation("WrittenPosts",  fields: [authorId],      references: [id])
+              favoritedBy     User? @relation("FavoritePosts", fields: [favoritedById], references: [id])
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let post = &schema.tables[1];
+
+        // Both FKs present
+        assert_eq!(post.foreign_keys.len(), 2);
+
+        // Both relations present and named
+        let written = post
+            .relations
+            .iter()
+            .find(|r| r.name.as_deref() == Some("WrittenPosts"));
+        let favorite = post
+            .relations
+            .iter()
+            .find(|r| r.name.as_deref() == Some("FavoritePosts"));
+        assert!(
+            written.is_some(),
+            "WrittenPosts relation must exist on Post"
+        );
+        assert!(
+            favorite.is_some(),
+            "FavoritePosts relation must exist on Post"
+        );
+    }
+
+    #[test]
+    fn unknown_block_attr_preserved_in_metadata() {
+        // Any @@attr not explicitly handled must land in unknown_features, not be silently dropped.
+        // This ensures future Prisma attributes (and custom generator plugins) survive round-trips.
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model User {
+              id Int @id
+              @@shardKey([id])
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let table = &schema.tables[0];
+        let feat = table
+            .metadata
+            .unknown_features
+            .iter()
+            .find(|f| f.name == "prisma.shardKey");
+        assert!(
+            feat.is_some(),
+            "@@shardKey should be preserved as unknown_feature 'prisma.shardKey'"
+        );
+    }
+
+    #[test]
+    fn unknown_field_attr_preserved_in_metadata() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model User {
+              id    Int    @id
+              email String @omit
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let table = &schema.tables[0];
+        let feat = table
+            .metadata
+            .unknown_features
+            .iter()
+            .find(|f| f.name == "prisma.field.email.omit");
+        assert!(
+            feat.is_some(),
+            "@omit should be preserved as unknown_feature 'prisma.field.email.omit'"
+        );
+        // Column must still be present in the IR (it exists in the DB)
+        assert!(table.columns.iter().any(|c| c.name == "email"));
+    }
+
+    #[test]
+    fn relation_map_populates_fk_name() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Post {
+              id       Int  @id
+              authorId Int
+              author   User @relation(fields: [authorId], references: [id], map: "fk_posts_author")
+            }
+            model User { id Int @id posts Post[] }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let post = schema.tables.iter().find(|t| t.name == "Post").unwrap();
+        let fk = post
+            .foreign_keys
+            .iter()
+            .find(|fk| fk.referenced_table == "User")
+            .unwrap();
+        assert_eq!(fk.name.as_deref(), Some("fk_posts_author"));
+    }
+
+    #[test]
+    fn relation_without_map_has_no_fk_name() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Post {
+              id       Int  @id
+              authorId Int
+              author   User @relation(fields: [authorId], references: [id])
+            }
+            model User { id Int @id posts Post[] }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let post = schema.tables.iter().find(|t| t.name == "Post").unwrap();
+        let fk = post
+            .foreign_keys
+            .iter()
+            .find(|fk| fk.referenced_table == "User")
+            .unwrap();
+        assert_eq!(fk.name, None);
+    }
+
+    #[test]
+    fn string_escape_sequences_in_map_and_default() {
+        let input = r#"
+            datasource db { provider = "postgresql" url = env("DATABASE_URL") }
+            model Post {
+              id    Int    @id
+              label String @default("hello \"world\"") @map("post_label")
+            }
+        "#;
+        let schema = parse_schema(input).unwrap();
+        let col = schema.tables[0]
+            .columns
+            .iter()
+            .find(|c| c.name == "label")
+            .unwrap();
+        assert!(
+            col.default.is_some(),
+            "escaped-quote default should parse without error"
+        );
+        assert_eq!(col.db_name.as_deref(), Some("post_label"));
+    }
+}

--- a/src/importer/prisma/mod.rs
+++ b/src/importer/prisma/mod.rs
@@ -13,6 +13,15 @@ use parser::{PrismaParser, Rule};
 
 // ── Public API ─────────────────────────────────────────────────────────────
 
+/// Importer for Prisma Schema Language (`.prisma`) files.
+pub struct PrismaImporter;
+
+impl super::Importer for PrismaImporter {
+    fn import(&self, input: &str) -> Result<crate::pivot::Schema, super::ImportError> {
+        parse_schema(input)
+    }
+}
+
 /// Parse a Prisma Schema Language string and return the pivot [`Schema`].
 ///
 /// # Errors

--- a/src/importer/prisma/parser.rs
+++ b/src/importer/prisma/parser.rs
@@ -1,0 +1,263 @@
+use pest::iterators::Pair;
+use pest_derive::Parser;
+
+use super::ast::{RawArg, RawAttr, RawField, RawModel, RawTypeAlias, RawValue};
+use crate::pivot::{DatabaseKind, Enum, EnumValue};
+
+#[derive(Parser)]
+#[grammar = "src/importer/prisma/grammar.pest"]
+pub(super) struct PrismaParser;
+
+impl From<pest::error::Error<Rule>> for super::super::ImportError {
+    fn from(e: pest::error::Error<Rule>) -> Self {
+        super::super::ImportError::Parse(e.to_string())
+    }
+}
+
+pub(super) fn extract_database_kind(pair: Pair<Rule>) -> DatabaseKind {
+    for child in pair.into_inner() {
+        if child.as_rule() != Rule::config_field {
+            continue;
+        }
+        let mut cf = child.into_inner();
+        if cf.next().map(|p| p.as_str()).unwrap_or("") != "provider" {
+            continue;
+        }
+        if let Some(val_pair) = cf.next() {
+            if let Some(inner) = val_pair.into_inner().next() {
+                let provider = match inner.as_rule() {
+                    Rule::string_lit => inner.into_inner().next().map(|s| s.as_str()).unwrap_or(""),
+                    Rule::identifier => inner.as_str(),
+                    _ => continue,
+                };
+                return match provider {
+                    "postgresql" | "postgres" => DatabaseKind::PostgreSql,
+                    "mysql" => DatabaseKind::MySql,
+                    "sqlite" => DatabaseKind::Sqlite,
+                    "sqlserver" => DatabaseKind::MsSql,
+                    "cockroachdb" => DatabaseKind::CockroachDb,
+                    other => DatabaseKind::Custom(other.to_string()),
+                };
+            }
+        }
+    }
+    DatabaseKind::PostgreSql
+}
+
+/// Parse a `model_block` or `view_block` (same inner structure) into a `RawModel`.
+pub(super) fn parse_model_block(pair: Pair<Rule>) -> Result<RawModel, super::super::ImportError> {
+    let mut inner = pair.into_inner();
+    let name = inner.next().unwrap().as_str().to_string();
+    let mut fields = Vec::new();
+    let mut block_attrs = Vec::new();
+
+    for entry in inner {
+        let child = entry.into_inner().next().unwrap();
+        match child.as_rule() {
+            Rule::field_decl => fields.push(parse_field_decl(child)?),
+            Rule::block_attribute => block_attrs.push(parse_attribute(child)?),
+            _ => {}
+        }
+    }
+    Ok(RawModel {
+        name,
+        fields,
+        block_attrs,
+    })
+}
+
+/// Parse a `type` alias block: `type Name = BaseType @attr...`
+pub(super) fn parse_type_alias(
+    pair: Pair<Rule>,
+) -> Result<RawTypeAlias, super::super::ImportError> {
+    let mut inner = pair.into_inner();
+    let name = inner.next().unwrap().as_str().to_string();
+    let base_type = inner.next().unwrap().as_str().to_string();
+    let attrs: Result<Vec<_>, _> = inner.map(parse_attribute).collect();
+    Ok(RawTypeAlias {
+        name,
+        base_type,
+        attrs: attrs?,
+    })
+}
+
+fn parse_field_decl(pair: Pair<Rule>) -> Result<RawField, super::super::ImportError> {
+    let mut inner = pair.into_inner();
+    let name = inner.next().unwrap().as_str().to_string();
+    let (base_type, unsupported_type, is_optional, is_array) =
+        parse_field_type(inner.next().unwrap());
+    let attrs: Result<Vec<_>, _> = inner.map(parse_attribute).collect();
+    Ok(RawField {
+        name,
+        base_type,
+        unsupported_type,
+        is_optional,
+        is_array,
+        attrs: attrs?,
+    })
+}
+
+/// Returns (base_type, unsupported_raw, is_optional, is_array).
+fn parse_field_type(pair: Pair<Rule>) -> (String, Option<String>, bool, bool) {
+    let child = pair.into_inner().next().unwrap();
+    match child.as_rule() {
+        Rule::unsupported_type => {
+            let mut ut = child.into_inner();
+            let raw = ut
+                .next()
+                .unwrap() // string_lit
+                .into_inner()
+                .next()
+                .unwrap() // string_inner
+                .as_str()
+                .to_string();
+            let modifier = ut.next().map(|m| m.as_str().to_string());
+            let is_opt = modifier.as_deref() == Some("?");
+            let is_arr = modifier.as_deref() == Some("[]");
+            (String::new(), Some(raw), is_opt, is_arr)
+        }
+        Rule::scalar_field_type => {
+            let mut sft = child.into_inner();
+            let base = sft.next().unwrap().as_str().to_string();
+            let modifier = sft.next().map(|m| m.as_str().to_string());
+            let is_opt = modifier.as_deref() == Some("?");
+            let is_arr = modifier.as_deref() == Some("[]");
+            (base, None, is_opt, is_arr)
+        }
+        _ => (String::new(), None, false, false),
+    }
+}
+
+/// Parse an `arg_list` pair into a list of raw arguments.
+fn parse_arg_list(arg_list: Pair<Rule>) -> Result<Vec<RawArg>, super::super::ImportError> {
+    let mut args = Vec::new();
+    for arg_pair in arg_list.into_inner() {
+        let child = arg_pair.into_inner().next().unwrap();
+        match child.as_rule() {
+            Rule::named_arg => {
+                let mut na = child.into_inner();
+                let key = na.next().unwrap().as_str().to_string();
+                let val = parse_attr_value(na.next().unwrap())?;
+                args.push(RawArg::Named(key, val));
+            }
+            Rule::positional_arg => {
+                let val = parse_attr_value(child.into_inner().next().unwrap())?;
+                args.push(RawArg::Positional(val));
+            }
+            _ => {}
+        }
+    }
+    Ok(args)
+}
+
+pub(super) fn parse_attribute(pair: Pair<Rule>) -> Result<RawAttr, super::super::ImportError> {
+    let mut inner = pair.into_inner();
+    let path = inner.next().unwrap().as_str().to_string();
+    let args = if let Some(args_pair) = inner.next() {
+        if let Some(arg_list) = args_pair.into_inner().next() {
+            parse_arg_list(arg_list)?
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+    Ok(RawAttr { path, args })
+}
+
+fn parse_attr_value(pair: Pair<Rule>) -> Result<RawValue, super::super::ImportError> {
+    let inner = pair.into_inner().next().unwrap();
+    match inner.as_rule() {
+        Rule::string_lit => {
+            let s = inner.into_inner().next().unwrap().as_str().to_string();
+            Ok(RawValue::Str(s))
+        }
+        Rule::integer => inner
+            .as_str()
+            .parse::<i64>()
+            .map(RawValue::Int)
+            .map_err(|_| {
+                super::super::ImportError::Schema(format!("invalid integer: {}", inner.as_str()))
+            }),
+        Rule::float_num => inner
+            .as_str()
+            .parse::<f64>()
+            .map(RawValue::Float)
+            .map_err(|_| {
+                super::super::ImportError::Schema(format!("invalid float: {}", inner.as_str()))
+            }),
+        Rule::identifier => Ok(RawValue::Ident(inner.as_str().to_string())),
+        Rule::array_value => {
+            let items: Result<Vec<_>, _> = inner.into_inner().map(parse_attr_value).collect();
+            Ok(RawValue::Array(items?))
+        }
+        Rule::function_call => {
+            let mut fc = inner.into_inner();
+            let name = fc.next().unwrap().as_str().to_string();
+            let args = if let Some(arg_list) = fc.next() {
+                parse_arg_list(arg_list)?
+            } else {
+                Vec::new()
+            };
+            Ok(RawValue::Call(name, args))
+        }
+        r => Err(super::super::ImportError::Schema(format!(
+            "unexpected rule in attr_value: {:?}",
+            r
+        ))),
+    }
+}
+
+pub(super) fn parse_enum_block(pair: Pair<Rule>) -> Result<Enum, super::super::ImportError> {
+    let mut inner = pair.into_inner();
+    let name = inner.next().unwrap().as_str().to_string();
+    let mut db_name: Option<String> = None;
+    let mut db_schema: Option<String> = None;
+    let mut values: Vec<EnumValue> = Vec::new();
+
+    for entry in inner {
+        let child = entry.into_inner().next().unwrap();
+        match child.as_rule() {
+            Rule::block_attribute => {
+                let attr = parse_attribute(child)?;
+                match attr.path.as_str() {
+                    "map" => {
+                        db_name = attr
+                            .positional(0)
+                            .and_then(|v| v.as_str().map(String::from))
+                    }
+                    "schema" => {
+                        db_schema = attr
+                            .positional(0)
+                            .and_then(|v| v.as_str().map(String::from))
+                    }
+                    _ => {}
+                }
+            }
+            Rule::enum_value => {
+                let mut ev = child.into_inner();
+                let val_name = ev.next().unwrap().as_str().to_string();
+                let mut val_db_name = None;
+                for attr_pair in ev {
+                    let attr = parse_attribute(attr_pair)?;
+                    if attr.path == "map" {
+                        val_db_name = attr
+                            .positional(0)
+                            .and_then(|v| v.as_str().map(String::from));
+                    }
+                }
+                values.push(EnumValue {
+                    name: val_name,
+                    db_name: val_db_name,
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(Enum {
+        name,
+        db_name,
+        db_schema,
+        values,
+    })
+}

--- a/src/importer/prisma/resolver.rs
+++ b/src/importer/prisma/resolver.rs
@@ -1,0 +1,538 @@
+use std::collections::{HashMap, HashSet};
+
+use super::ast::{RawAttr, RawModel, RawTypeAlias, RawValue};
+use super::mappers;
+use crate::pivot::metadata::{OrmKind, OrmMetadata, UnknownFeature};
+use crate::pivot::relation::{
+    CascadeOptions, ForeignKey, JunctionTable, ReferentialAction, Relation, RelationKind,
+};
+use crate::pivot::table::{
+    Behavior, Column, Index, IndexType, PrimaryKey, Table, UniqueConstraint,
+};
+use crate::pivot::types::{ColumnType, ScalarType};
+use crate::pivot::view::{View, ViewColumn};
+
+// ── Structs ────────────────────────────────────────────────────────────────
+
+struct RelInfo {
+    owner: String,
+    target: String,
+    owner_cols: Vec<String>,
+    target_refs: Vec<String>,
+    on_delete: Option<ReferentialAction>,
+    on_update: Option<ReferentialAction>,
+    rel_name: Option<String>,
+    fk_name: Option<String>,
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+fn push_unknown_attrs(
+    metadata: &mut OrmMetadata,
+    attrs: &[RawAttr],
+    known: &[&str],
+    name_prefix: &str,
+) {
+    for attr in attrs {
+        if !known.contains(&attr.path.as_str()) {
+            metadata.unknown_features.push(UnknownFeature {
+                name: format!("{}{}", name_prefix, attr.path),
+                value: mappers::raw_args_to_json(&attr.args),
+                recoverable: true,
+            });
+        }
+    }
+}
+
+// ── Resolvers ──────────────────────────────────────────────────────────────
+
+pub(super) fn resolve_views(
+    raw_views: Vec<RawModel>,
+    enum_names: &HashSet<String>,
+    type_aliases: &HashMap<String, RawTypeAlias>,
+) -> Result<Vec<View>, super::super::ImportError> {
+    raw_views
+        .into_iter()
+        .map(|raw| {
+            let (db_name, db_schema) = mappers::extract_db_naming(&raw);
+
+            let columns = raw
+                .fields
+                .iter()
+                .map(|f| {
+                    let db_name = f
+                        .attr("map")
+                        .and_then(|a| a.positional(0))
+                        .and_then(|v| v.as_str().map(String::from));
+                    ViewColumn {
+                        name: f.name.clone(),
+                        db_name,
+                    }
+                })
+                .collect();
+
+            let mut metadata = OrmMetadata {
+                source_orm: Some(OrmKind::Prisma),
+                ..Default::default()
+            };
+            if raw.block_attr("ignore").is_some() {
+                metadata.unknown_features.push(UnknownFeature {
+                    name: "prisma.ignore".to_string(),
+                    value: serde_json::json!(true),
+                    recoverable: true,
+                });
+            }
+
+            let ignored: Vec<String> = raw
+                .fields
+                .iter()
+                .filter(|f| f.attr("ignore").is_some())
+                .map(|f| f.name.clone())
+                .collect();
+            if !ignored.is_empty() {
+                metadata.unknown_features.push(UnknownFeature {
+                    name: "prisma.ignoredFields".to_string(),
+                    value: serde_json::json!(ignored),
+                    recoverable: true,
+                });
+            }
+
+            const KNOWN_VIEW_BLOCK_ATTRS: &[&str] = &["map", "schema", "ignore"];
+            push_unknown_attrs(
+                &mut metadata,
+                &raw.block_attrs,
+                KNOWN_VIEW_BLOCK_ATTRS,
+                "prisma.",
+            );
+
+            let _ = (enum_names, type_aliases); // view columns not resolved into IR scalars yet
+
+            Ok(View {
+                name: raw.name.clone(),
+                db_name,
+                db_schema,
+                definition: String::new(),
+                columns,
+                updatable: false,
+                metadata,
+            })
+        })
+        .collect()
+}
+
+pub(super) fn resolve_models(
+    raw_models: Vec<RawModel>,
+    model_names: &HashSet<String>,
+    enum_names: &HashSet<String>,
+    type_aliases: &HashMap<String, RawTypeAlias>,
+) -> Result<Vec<Table>, super::super::ImportError> {
+    let mut rel_infos: Vec<RelInfo> = Vec::new();
+    let mut implicit_m2m: Vec<(String, String, Option<String>)> = Vec::new();
+
+    for raw in &raw_models {
+        for field in &raw.fields {
+            if !model_names.contains(&field.base_type) {
+                continue;
+            }
+
+            if let Some(rel_attr) = field.attr("relation") {
+                let owner_cols = rel_attr
+                    .named("fields")
+                    .map(RawValue::as_string_array)
+                    .unwrap_or_default();
+                if owner_cols.is_empty() {
+                    continue;
+                }
+
+                let rel_name = rel_attr
+                    .named("name")
+                    .and_then(|v| v.as_str().map(String::from))
+                    .or_else(|| {
+                        rel_attr
+                            .positional(0)
+                            .and_then(|v| v.as_str().map(String::from))
+                    });
+
+                rel_infos.push(RelInfo {
+                    owner: raw.name.clone(),
+                    target: field.base_type.clone(),
+                    owner_cols,
+                    target_refs: rel_attr
+                        .named("references")
+                        .map(RawValue::as_string_array)
+                        .unwrap_or_default(),
+                    on_delete: rel_attr
+                        .named("onDelete")
+                        .and_then(|v| v.as_ident())
+                        .and_then(mappers::parse_referential_action),
+                    on_update: rel_attr
+                        .named("onUpdate")
+                        .and_then(|v| v.as_ident())
+                        .and_then(mappers::parse_referential_action),
+                    rel_name,
+                    fk_name: rel_attr
+                        .named("map")
+                        .and_then(|v| v.as_str().map(String::from)),
+                });
+            } else if field.is_array {
+                let other = raw_models.iter().find(|m| m.name == field.base_type);
+                let other_is_array = other
+                    .map(|m| {
+                        m.fields
+                            .iter()
+                            .any(|f| f.base_type == raw.name && f.is_array)
+                    })
+                    .unwrap_or(false);
+                let other_has_fk = other
+                    .map(|m| {
+                        m.fields.iter().any(|f| {
+                            f.base_type == raw.name
+                                && f.attr("relation")
+                                    .map(|a| a.named("fields").is_some())
+                                    .unwrap_or(false)
+                        })
+                    })
+                    .unwrap_or(false);
+
+                if other_is_array && !other_has_fk {
+                    let mut pair = [raw.name.clone(), field.base_type.clone()];
+                    pair.sort();
+                    let rel_name = field
+                        .attr("relation")
+                        .and_then(|a| a.named("name").or_else(|| a.positional(0)))
+                        .and_then(|v| v.as_str().map(String::from));
+                    let key = (pair[0].clone(), pair[1].clone(), rel_name);
+                    if !implicit_m2m.contains(&key) {
+                        implicit_m2m.push(key);
+                    }
+                }
+            }
+        }
+    }
+
+    raw_models
+        .iter()
+        .map(|raw| {
+            let mut table = build_scalar_table(raw, model_names, enum_names, type_aliases)?;
+
+            for ri in rel_infos.iter().filter(|r| r.owner == raw.name) {
+                table.foreign_keys.push(ForeignKey {
+                    name: ri.fk_name.clone(),
+                    columns: ri.owner_cols.clone(),
+                    referenced_table: ri.target.clone(),
+                    referenced_columns: ri.target_refs.clone(),
+                    on_delete: ri.on_delete.clone(),
+                    on_update: ri.on_update.clone(),
+                });
+            }
+
+            for ri in rel_infos
+                .iter()
+                .filter(|r| r.owner == raw.name || r.target == raw.name)
+            {
+                let is_owner = ri.owner == raw.name;
+                let other_name = if is_owner { &ri.target } else { &ri.owner };
+
+                let back_field = raw_models
+                    .iter()
+                    .find(|m| &m.name == other_name)
+                    .and_then(|m| {
+                        m.fields.iter().find(|f| {
+                            if f.base_type != raw.name {
+                                return false;
+                            }
+                            let f_rel_name = f
+                                .attr("relation")
+                                .and_then(|a| a.named("name").or_else(|| a.positional(0)))
+                                .and_then(|v| v.as_str());
+                            match (ri.rel_name.as_deref(), f_rel_name) {
+                                (Some(rn), Some(fn_)) => rn == fn_,
+                                (None, None) => true,
+                                _ => false,
+                            }
+                        })
+                    });
+
+                let back_is_array = back_field.map(|f| f.is_array).unwrap_or(true);
+                let kind = if back_is_array {
+                    RelationKind::OneToMany
+                } else {
+                    RelationKind::OneToOne {
+                        owner_table: ri.owner.clone(),
+                    }
+                };
+
+                table.relations.push(Relation {
+                    name: ri.rel_name.clone(),
+                    kind,
+                    from_table: ri.target.clone(),
+                    from_fields: ri.target_refs.clone(),
+                    to_table: ri.owner.clone(),
+                    to_fields: ri.owner_cols.clone(),
+                    cascade: CascadeOptions {
+                        on_delete: ri.on_delete.clone(),
+                        on_update: ri.on_update.clone(),
+                    },
+                });
+            }
+
+            for (a, b, rel_name) in &implicit_m2m {
+                let (our_side, other_side) = if a == &raw.name {
+                    (a, b)
+                } else if b == &raw.name {
+                    (b, a)
+                } else {
+                    continue;
+                };
+                table.relations.push(Relation {
+                    name: rel_name.clone(),
+                    kind: RelationKind::ManyToMany {
+                        junction: JunctionTable {
+                            table: format!("_{}To{}", a, b),
+                            from_column: "A".to_string(),
+                            to_column: "B".to_string(),
+                        },
+                        implicit: true,
+                    },
+                    from_table: our_side.clone(),
+                    from_fields: Vec::new(),
+                    to_table: other_side.clone(),
+                    to_fields: Vec::new(),
+                    cascade: CascadeOptions {
+                        on_delete: None,
+                        on_update: None,
+                    },
+                });
+            }
+
+            Ok(table)
+        })
+        .collect()
+}
+
+fn build_scalar_table(
+    raw: &RawModel,
+    model_names: &HashSet<String>,
+    enum_names: &HashSet<String>,
+    type_aliases: &HashMap<String, RawTypeAlias>,
+) -> Result<Table, super::super::ImportError> {
+    let (db_name, db_schema) = mappers::extract_db_naming(raw);
+
+    let primary_key = raw.block_attr("id").map(|a| {
+        let cols = mappers::extract_columns_from_attr(a);
+        let name = a.named("map").and_then(|v| v.as_str().map(String::from));
+        PrimaryKey {
+            name,
+            columns: cols,
+        }
+    });
+
+    let unique_constraints = raw
+        .block_attrs_all("unique")
+        .map(|a| {
+            let cols = mappers::extract_columns_from_attr(a);
+            let name = a.named("map").and_then(|v| v.as_str().map(String::from));
+            UniqueConstraint {
+                name,
+                columns: cols,
+            }
+        })
+        .collect();
+
+    let mut indexes: Vec<Index> = raw
+        .block_attrs_all("index")
+        .filter_map(|a| {
+            let cols_val = a.named("fields").or_else(|| a.positional(0))?;
+            let index_type = a
+                .named("type")
+                .and_then(|v| v.as_ident())
+                .map(mappers::map_index_type);
+            Some(Index {
+                name: a.named("name").and_then(|n| n.as_str().map(String::from)),
+                columns: mappers::extract_index_columns(cols_val),
+                unique: false,
+                partial: None,
+                index_type,
+                include: Vec::new(),
+            })
+        })
+        .collect();
+
+    for a in raw.block_attrs_all("fulltext") {
+        let cols_val = a.named("fields").or_else(|| a.positional(0));
+        indexes.push(Index {
+            name: a.named("name").and_then(|n| n.as_str().map(String::from)),
+            columns: cols_val
+                .map(mappers::extract_index_columns)
+                .unwrap_or_default(),
+            unique: false,
+            partial: None,
+            index_type: Some(IndexType::Custom {
+                name: "fulltext".to_string(),
+            }),
+            include: Vec::new(),
+        });
+    }
+
+    let mut metadata = OrmMetadata {
+        source_orm: Some(OrmKind::Prisma),
+        ..Default::default()
+    };
+
+    if raw.block_attr("ignore").is_some() {
+        metadata.unknown_features.push(UnknownFeature {
+            name: "prisma.ignore".to_string(),
+            value: serde_json::json!(true),
+            recoverable: true,
+        });
+    }
+
+    const KNOWN_BLOCK_ATTRS: &[&str] = &[
+        "map", "schema", "id", "unique", "index", "fulltext", "ignore",
+    ];
+    push_unknown_attrs(
+        &mut metadata,
+        &raw.block_attrs,
+        KNOWN_BLOCK_ATTRS,
+        "prisma.",
+    );
+
+    let mut table = Table {
+        name: raw.name.clone(),
+        db_name,
+        db_schema,
+        columns: Vec::new(),
+        primary_key,
+        indexes,
+        unique_constraints,
+        check_constraints: Vec::new(),
+        foreign_keys: Vec::new(),
+        relations: Vec::new(),
+        inheritance: None,
+        behaviors: Vec::new(),
+        metadata,
+    };
+
+    let mut ignored_fields: Vec<String> = Vec::new();
+
+    for field in &raw.fields {
+        if model_names.contains(&field.base_type) {
+            continue;
+        }
+
+        let alias = type_aliases.get(&field.base_type);
+        let effective_base: &str = alias
+            .map(|a| a.base_type.as_str())
+            .unwrap_or(&field.base_type);
+        let alias_attrs = alias.map(|a| a.attrs.as_slice()).unwrap_or(&[]);
+
+        let scalar = if let Some(raw_type) = &field.unsupported_type {
+            ScalarType::Unsupported {
+                type_name: raw_type.clone(),
+            }
+        } else if enum_names.contains(effective_base) {
+            ScalarType::Enum {
+                name: effective_base.to_string(),
+            }
+        } else if let Some(s) = mappers::map_scalar_type(effective_base) {
+            s
+        } else {
+            ScalarType::Unsupported {
+                type_name: effective_base.to_string(),
+            }
+        };
+
+        let db_hint = field
+            .attrs
+            .iter()
+            .chain(alias_attrs.iter())
+            .find(|a| a.path.starts_with("db."))
+            .and_then(|a| mappers::map_db_hint(&a.path, &a.args));
+
+        let default = field
+            .attr("default")
+            .or_else(|| alias_attrs.iter().find(|a| a.path == "default"))
+            .and_then(|a| a.positional(0))
+            .and_then(mappers::map_default_value);
+
+        let db_name = field
+            .attr("map")
+            .and_then(|a| a.positional(0))
+            .and_then(|v| v.as_str().map(String::from));
+
+        table.columns.push(Column {
+            name: field.name.clone(),
+            db_name,
+            col_type: ColumnType {
+                scalar,
+                db_hint,
+                array: field.is_array,
+            },
+            nullable: field.is_optional,
+            default,
+        });
+
+        let id_attr = field
+            .attr("id")
+            .or_else(|| alias_attrs.iter().find(|a| a.path == "id"));
+        if id_attr.is_some() && table.primary_key.is_none() {
+            let pk_name = id_attr
+                .and_then(|a| a.named("map"))
+                .and_then(|v| v.as_str().map(String::from));
+            table.primary_key = Some(PrimaryKey {
+                name: pk_name,
+                columns: vec![field.name.clone()],
+            });
+        }
+
+        let has_unique =
+            field.attr("unique").is_some() || alias_attrs.iter().any(|a| a.path == "unique");
+        if has_unique {
+            table.unique_constraints.push(UniqueConstraint {
+                name: None,
+                columns: vec![field.name.clone()],
+            });
+        }
+
+        let has_updated_at =
+            field.attr("updatedAt").is_some() || alias_attrs.iter().any(|a| a.path == "updatedAt");
+        if has_updated_at {
+            table.behaviors.push(Behavior::UpdatedAt {
+                column: field.name.clone(),
+            });
+        }
+
+        if field.attr("ignore").is_some() {
+            ignored_fields.push(field.name.clone());
+        }
+
+        const KNOWN_FIELD_ATTRS: &[&str] = &[
+            "id",
+            "default",
+            "unique",
+            "map",
+            "updatedAt",
+            "ignore",
+            "relation",
+        ];
+        for attr in &field.attrs {
+            if !KNOWN_FIELD_ATTRS.contains(&attr.path.as_str()) && !attr.path.starts_with("db.") {
+                table.metadata.unknown_features.push(UnknownFeature {
+                    name: format!("prisma.field.{}.{}", field.name, attr.path),
+                    value: mappers::raw_args_to_json(&attr.args),
+                    recoverable: true,
+                });
+            }
+        }
+    }
+
+    if !ignored_fields.is_empty() {
+        table.metadata.unknown_features.push(UnknownFeature {
+            name: "prisma.ignoredFields".to_string(),
+            value: serde_json::json!(ignored_fields),
+            recoverable: true,
+        });
+    }
+
+    Ok(table)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod exporter;
 pub mod importer;
 pub mod pivot;
+pub mod registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod importer;
 pub mod pivot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod exporter;
 pub mod importer;
 pub mod pivot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,7 @@ fn main() {
             } else {
                 let detected = registry::detect(&path_str).unwrap_or_else(|| {
                     eprintln!("error: could not detect ORM format for '{path_str}'");
-                    eprintln!(
-                        "Use --from to specify: transf-orm convert --from <orm> {path_str}"
-                    );
+                    eprintln!("Use --from to specify: transf-orm convert --from <orm> {path_str}");
                     std::process::exit(1);
                 });
                 if !detected.certain {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,81 @@
+use clap::{Parser, Subcommand};
+use transf_orm_cli::registry;
+
+#[derive(Parser)]
+#[command(name = "transf-orm", about = "ORM schema converter")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Convert an ORM schema to the pivot IR (canonical JSON)
+    Convert {
+        /// Path to the schema file or directory
+        path: std::path::PathBuf,
+        /// Force the source ORM format (skips detection and confirmation)
+        #[arg(long, value_name = "ORM")]
+        from: Option<String>,
+    },
+}
+
 fn main() {
-    let path = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "test.prisma".to_string());
-    let input = std::fs::read_to_string(&path).unwrap_or_else(|e| {
-        eprintln!("error reading {path}: {e}");
-        std::process::exit(1);
-    });
-    match transf_orm_cli::importer::prisma::parse_schema(&input) {
-        Ok(schema) => println!("{}", schema.to_canonical_json().unwrap()),
-        Err(e) => {
-            eprintln!("parse error: {e}");
-            std::process::exit(1);
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Convert { path, from } => {
+            let path_str = path.to_string_lossy();
+
+            let orm = if let Some(name) = from {
+                registry::find_by_name(&name).unwrap_or_else(|| {
+                    eprintln!(
+                        "error: unknown ORM '{name}'. Valid options: {}",
+                        registry::names().join(", ")
+                    );
+                    std::process::exit(1);
+                })
+            } else {
+                let detected = registry::detect(&path_str).unwrap_or_else(|| {
+                    eprintln!("error: could not detect ORM format for '{path_str}'");
+                    eprintln!(
+                        "Use --from to specify: transf-orm convert --from <orm> {path_str}"
+                    );
+                    std::process::exit(1);
+                });
+                if !detected.certain {
+                    eprint!(
+                        "Detected: {} — press Enter to confirm, Ctrl+C to cancel: ",
+                        detected.display_name
+                    );
+                    let mut input = String::new();
+                    if std::io::stdin().read_line(&mut input).is_err() || !input.trim().is_empty() {
+                        eprintln!(
+                            "Use --from to specify: transf-orm convert --from <orm> {path_str}"
+                        );
+                        std::process::exit(1);
+                    }
+                }
+                detected
+            };
+
+            let make_importer = orm.make_importer.unwrap_or_else(|| {
+                eprintln!("error: {} does not support importing", orm.display_name);
+                std::process::exit(1);
+            });
+
+            let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+                eprintln!("error reading {path_str}: {e}");
+                std::process::exit(1);
+            });
+
+            match make_importer().import(&content) {
+                Ok(schema) => println!("{}", schema.to_canonical_json().unwrap()),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,16 @@
 fn main() {
-    println!("Transf-ORM CLI");
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "test.prisma".to_string());
+    let input = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        eprintln!("error reading {path}: {e}");
+        std::process::exit(1);
+    });
+    match transf_orm_cli::importer::prisma::parse_schema(&input) {
+        Ok(schema) => println!("{}", schema.to_canonical_json().unwrap()),
+        Err(e) => {
+            eprintln!("parse error: {e}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/pivot/mod.rs
+++ b/src/pivot/mod.rs
@@ -137,9 +137,9 @@ pub struct Sequence {
 ///
 /// # Serialization
 ///
-/// `serde_json` uses `BTreeMap` by default (without the `preserve_order` feature),
-/// so JSON object keys are already sorted alphabetically. [`Schema::to_canonical_json`]
-/// relies on this property to produce deterministic output suitable for `git diff`.
+/// [`Schema::to_canonical_json`] routes serialization through [`serde_json::Value`]
+/// (which stores object entries in a `BTreeMap`) to guarantee alphabetical key order
+/// regardless of struct field declaration order — suitable for meaningful `git diff`.
 ///
 /// # Examples
 ///
@@ -199,12 +199,17 @@ impl Schema {
 
     /// Serialize to canonical JSON — pretty-printed with alphabetically sorted keys.
     ///
+    /// Keys are sorted by routing serialization through [`serde_json::Value`], which
+    /// stores object entries in a `BTreeMap` and therefore iterates them in alphabetical
+    /// order regardless of the struct field order.
+    ///
     /// # Errors
     ///
     /// Returns an error if any field cannot be serialized (e.g. a non-finite float
     /// inside a [`types::LiteralValue::Float`] default value).
     pub fn to_canonical_json(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string_pretty(self)
+        let value = serde_json::to_value(self)?;
+        serde_json::to_string_pretty(&value)
     }
 
     /// Deserialize a `Schema` from a canonical JSON string.
@@ -220,11 +225,11 @@ impl Schema {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::metadata::OrmMetadata;
     use super::relation::{CascadeOptions, JunctionTable, RelationKind};
     use super::table::{Behavior, Column, PrimaryKey, Table};
     use super::types::{ColumnType, DefaultFn, DefaultValue, ScalarType};
+    use super::*;
 
     fn user_table() -> Table {
         Table {
@@ -257,14 +262,19 @@ mod tests {
                     default: Some(DefaultValue::Function(DefaultFn::Now)),
                 },
             ],
-            primary_key: Some(PrimaryKey { name: None, columns: vec!["id".to_string()] }),
+            primary_key: Some(PrimaryKey {
+                name: None,
+                columns: vec!["id".to_string()],
+            }),
             indexes: Vec::new(),
             unique_constraints: Vec::new(),
             check_constraints: Vec::new(),
             foreign_keys: Vec::new(),
             relations: Vec::new(),
             inheritance: None,
-            behaviors: vec![Behavior::CreatedAt { column: "createdAt".to_string() }],
+            behaviors: vec![Behavior::CreatedAt {
+                column: "createdAt".to_string(),
+            }],
             metadata: OrmMetadata::default(),
         }
     }
@@ -284,12 +294,46 @@ mod tests {
     fn canonical_json_has_sorted_keys() {
         let schema = Schema::new(DatabaseKind::PostgreSql);
         let json = schema.to_canonical_json().unwrap();
-        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let obj = value.as_object().unwrap();
-        let keys: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
-        let mut sorted = keys.clone();
+
+        // Extract top-level keys in the order they appear in the raw string,
+        // without going through serde_json::Value (which uses BTreeMap and would
+        // sort keys on its own, masking a bug in to_canonical_json).
+        let keys_in_order: Vec<&str> = json
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if trimmed.starts_with('"') && trimmed.contains("\": ") {
+                    trimmed
+                        .strip_prefix('"')
+                        .and_then(|s| s.split_once("\": ").map(|(k, _)| k))
+                } else {
+                    None
+                }
+            })
+            // Top-level keys are at indent level 2 (two spaces); nested keys are deeper.
+            // Filter to lines that start with exactly two spaces in the original string.
+            .collect::<Vec<_>>();
+
+        // Re-derive only the top-level keys (indented with exactly 2 spaces).
+        let top_level_keys: Vec<&str> = json
+            .lines()
+            .filter(|line| {
+                line.starts_with("  \"") && !line.starts_with("   ") && line.contains("\": ")
+            })
+            .filter_map(|line| {
+                line.trim()
+                    .strip_prefix('"')
+                    .and_then(|s| s.split_once("\": ").map(|(k, _)| k))
+            })
+            .collect();
+
+        let mut sorted = top_level_keys.clone();
         sorted.sort();
-        assert_eq!(keys, sorted, "JSON keys must be alphabetically sorted");
+        assert_eq!(
+            top_level_keys, sorted,
+            "top-level JSON keys must be alphabetically sorted in the raw string"
+        );
+        let _ = keys_in_order; // used above to establish the approach
     }
 
     #[test]
@@ -310,7 +354,10 @@ mod tests {
             from_fields: vec!["id".to_string()],
             to_table: "Tag".to_string(),
             to_fields: vec!["id".to_string()],
-            cascade: CascadeOptions { on_delete: None, on_update: None },
+            cascade: CascadeOptions {
+                on_delete: None,
+                on_update: None,
+            },
         };
 
         let json = serde_json::to_string(&relation).unwrap();

--- a/src/pivot/procedure.rs
+++ b/src/pivot/procedure.rs
@@ -16,7 +16,9 @@ pub enum FunctionLanguage {
     PlPerl,
     /// JavaScript (e.g. PL/V8 in PostgreSQL, or Edge Functions in Supabase).
     JavaScript,
-    Custom { name: String },
+    Custom {
+        name: String,
+    },
 }
 
 /// PostgreSQL function volatility category — affects query planning and caching.

--- a/src/pivot/relation.rs
+++ b/src/pivot/relation.rs
@@ -63,7 +63,9 @@ pub struct JunctionTable {
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum RelationKind {
     /// One-to-one — `owner_table` holds the foreign key.
-    OneToOne { owner_table: String },
+    OneToOne {
+        owner_table: String,
+    },
     OneToMany,
     ManyToMany {
         junction: JunctionTable,

--- a/src/pivot/table.rs
+++ b/src/pivot/table.rs
@@ -69,7 +69,9 @@ pub enum IndexType {
     Brin,
     /// PostgreSQL SP-GiST — space-partitioned generalized search tree.
     SpGist,
-    Custom { name: String },
+    Custom {
+        name: String,
+    },
 }
 
 /// A database index on one or more columns of a table.

--- a/src/pivot/types.rs
+++ b/src/pivot/types.rs
@@ -14,12 +14,22 @@ pub enum ScalarType {
     BigInt,
     Float,
     Double,
-    Decimal { precision: u8, scale: u8 },
+    Decimal {
+        precision: u8,
+        scale: u8,
+    },
     Boolean,
     Date,
-    Time { precision: u8 },
-    DateTime { precision: u8 },
-    Timestamp { precision: u8, with_timezone: bool },
+    Time {
+        precision: u8,
+    },
+    DateTime {
+        precision: u8,
+    },
+    Timestamp {
+        precision: u8,
+        with_timezone: bool,
+    },
     Json,
     /// PostgreSQL JSONB — binary JSON with indexing support.
     JsonB,
@@ -35,12 +45,18 @@ pub enum ScalarType {
     TsVector,
     /// PostgreSQL TSQUERY — full-text search query.
     TsQuery,
+    /// Reference to a named [`Enum`](crate::pivot::Enum) defined in the same schema.
+    Enum {
+        name: String,
+    },
     /// Raw database type with no known IR equivalent.
     ///
     /// Preserved verbatim so round-trips back to the source ORM are lossless.
     /// Exporters targeting a different ORM must decide how to handle this — usually
     /// by emitting a warning and carrying the raw expression through.
-    Unsupported { type_name: String },
+    Unsupported {
+        type_name: String,
+    },
 }
 
 /// Database-specific type hint layered on top of [`ScalarType`].
@@ -51,29 +67,93 @@ pub enum ScalarType {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum DbHint {
-    VarChar { length: u32 },
-    Char { length: u32 },
+    // ── String types ───────────────────────────────────────────────────────
+    VarChar {
+        length: u32,
+    },
+    Char {
+        length: u32,
+    },
     Text,
+    TinyText,
+    MediumText,
+    LongText,
+    // ── Integer types ──────────────────────────────────────────────────────
+    /// Explicit SMALLINT / INT2 column type hint (e.g. `@db.SmallInt`).
+    SmallInt,
+    /// Explicit INT / INT4 column type hint (e.g. MySQL `@db.Int`).
+    Int,
+    /// Explicit BIGINT / INT8 column type hint (e.g. `@db.BigInt`).
+    BigInt,
     TinyInt,
     MediumInt,
     Year,
-    VarBinary { length: u32 },
-    Binary { length: u32 },
+    // ── Floating point ─────────────────────────────────────────────────────
+    /// Single-precision FLOAT (4 bytes).
+    Float,
+    /// DOUBLE PRECISION / FLOAT8 (8 bytes).
+    DoublePrecision,
+    /// REAL — alias for single-precision float in PostgreSQL.
+    Real,
+    Numeric {
+        precision: u8,
+        scale: u8,
+    },
+    // ── Binary / blob types ────────────────────────────────────────────────
+    VarBinary {
+        length: u32,
+    },
+    Binary {
+        length: u32,
+    },
     TinyBlob,
     Blob,
     MediumBlob,
     LongBlob,
-    TinyText,
-    MediumText,
-    LongText,
-    Numeric { precision: u8, scale: u8 },
+    /// PostgreSQL BYTEA — variable-length binary string.
+    ByteA,
+    /// BIT(n) or VARBIT(n) — fixed or variable-length bit string.
+    Bit {
+        length: Option<u32>,
+    },
+    // ── Date / time ────────────────────────────────────────────────────────
+    /// DATE — calendar date without time component.
+    Date,
+    /// TIME(n) — time of day without date.
+    Time {
+        precision: u8,
+    },
+    /// MySQL DATETIME(n) — date and time without timezone.
+    DateTime {
+        precision: u8,
+    },
+    /// MySQL TIMESTAMP(n) or PostgreSQL TIMESTAMP(n) without timezone.
+    Timestamp {
+        precision: u8,
+    },
     /// PostgreSQL TIMESTAMPTZ shorthand.
     Timestamptz,
     /// PostgreSQL TIMETZ shorthand.
     Timetz,
     Interval,
+    // ── PostgreSQL-specific ────────────────────────────────────────────────
+    /// PostgreSQL UUID column type (as opposed to storing UUID as TEXT).
+    Uuid,
+    /// PostgreSQL INET — IPv4 or IPv6 host address.
+    Inet,
+    /// PostgreSQL CIDR — network address.
+    Cidr,
+    /// PostgreSQL XML.
+    Xml,
+    /// PostgreSQL MONEY.
+    Money,
+    /// PostgreSQL OID.
+    Oid,
+    // ── Catch-all ──────────────────────────────────────────────────────────
     /// Arbitrary database type expression not covered by other variants.
-    Custom { type_expr: String },
+    Custom {
+        type_expr: String,
+    },
 }
 
 /// Full type descriptor for a column: abstract kind + optional DB-specific hint.
@@ -105,7 +185,11 @@ pub struct ColumnType {
 impl ColumnType {
     /// Shorthand for a plain scalar column with no DB hint and no array wrapper.
     pub fn simple(scalar: ScalarType) -> Self {
-        Self { scalar, db_hint: None, array: false }
+        Self {
+            scalar,
+            db_hint: None,
+            array: false,
+        }
     }
 }
 
@@ -134,7 +218,9 @@ pub enum DefaultFn {
     /// `@default(autoincrement())` and Drizzle's `serial()` at the IR level.
     AutoIncrement,
     /// Custom function call not covered by other variants.
-    Custom { expr: String },
+    Custom {
+        expr: String,
+    },
 }
 
 /// Default value assigned to a column when no explicit value is provided on insert.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,49 @@
+use crate::exporter::Exporter;
+use crate::importer::prisma::PrismaImporter;
+use crate::importer::Importer;
+
+/// Describes an ORM known to the tool — its CLI name, file extensions,
+/// and optional importer/exporter factories.
+pub struct OrmDescriptor {
+    /// Lowercase CLI name used with `--from` / `--to`.
+    pub name: &'static str,
+    /// Human-readable name for display messages.
+    pub display_name: &'static str,
+    /// File extensions that identify this ORM's schema files.
+    pub extensions: &'static [&'static str],
+    /// `true` when the extension alone is unambiguous (no confirmation needed).
+    pub certain: bool,
+    /// Factory for an importer, if this ORM can be used as a source.
+    pub make_importer: Option<fn() -> Box<dyn Importer>>,
+    /// Factory for an exporter, if this ORM can be used as a target.
+    pub make_exporter: Option<fn() -> Box<dyn Exporter>>,
+}
+
+/// All ORMs known to the tool.
+///
+/// Adding a new ORM = adding one entry here. Nothing else changes.
+pub static ORMS: &[OrmDescriptor] = &[OrmDescriptor {
+    name: "prisma",
+    display_name: "Prisma",
+    extensions: &["prisma"],
+    certain: true,
+    make_importer: Some(|| Box::new(PrismaImporter)),
+    make_exporter: None,
+}];
+
+/// Detect the ORM from a file path's extension.
+pub fn detect(path: &str) -> Option<&'static OrmDescriptor> {
+    let ext = std::path::Path::new(path).extension()?.to_str()?;
+    ORMS.iter().find(|o| o.extensions.contains(&ext))
+}
+
+/// Find an ORM descriptor by its CLI name (case-insensitive).
+pub fn find_by_name(name: &str) -> Option<&'static OrmDescriptor> {
+    ORMS.iter()
+        .find(|o| o.name.eq_ignore_ascii_case(name))
+}
+
+/// List CLI names of all known ORMs.
+pub fn names() -> Vec<&'static str> {
+    ORMS.iter().map(|o| o.name).collect()
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -39,8 +39,7 @@ pub fn detect(path: &str) -> Option<&'static OrmDescriptor> {
 
 /// Find an ORM descriptor by its CLI name (case-insensitive).
 pub fn find_by_name(name: &str) -> Option<&'static OrmDescriptor> {
-    ORMS.iter()
-        .find(|o| o.name.eq_ignore_ascii_case(name))
+    ORMS.iter().find(|o| o.name.eq_ignore_ascii_case(name))
 }
 
 /// List CLI names of all known ORMs.

--- a/test.prisma
+++ b/test.prisma
@@ -1,0 +1,271 @@
+// ── Configuration ────────────────────────────────────────────────────────────
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+  schemas  = ["public", "shop", "analytics"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema", "fullTextSearch", "views"]
+}
+
+// ── Type aliases ──────────────────────────────────────────────────────────────
+
+/// Shorthand for a UUID primary key with auto-generation.
+type UuidPk = String @id @default(uuid()) @db.Uuid
+
+// ── Enums ─────────────────────────────────────────────────────────────────────
+
+enum Role {
+  USER
+  MODERATOR @map("moderator")
+  ADMIN     @map("admin")
+
+  @@schema("public")
+}
+
+enum PostStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+
+  @@map("post_status")
+  @@schema("public")
+}
+
+enum OrderStatus {
+  PENDING
+  PAID
+  SHIPPED
+  DELIVERED
+  CANCELLED
+
+  @@map("order_status")
+  @@schema("shop")
+}
+
+// ── Models ────────────────────────────────────────────────────────────────────
+
+model User {
+  /// Unique identifier — UUID stored in a native uuid column.
+  id          UuidPk                         // type alias inlining
+  email       String    @unique @db.VarChar(255)
+  username    String    @unique @db.VarChar(50)
+  displayName String?   @db.VarChar(100)    @map("display_name")
+  bio         String?   @db.Text
+  role        Role      @default(USER)
+  score       Int       @default(0)         @db.SmallInt
+  balance     Decimal   @default(0)         @db.Decimal(12, 2)
+  metadata    Json?     @db.JsonB
+  ipAddress   String?   @db.Inet            @map("ip_address")
+  tags        String[]                      // scalar array
+  createdAt   DateTime  @default(now())     @map("created_at")
+  updatedAt   DateTime  @updatedAt          @map("updated_at")
+  deletedAt   DateTime? @map("deleted_at")
+
+  // Relations
+  profile         Profile?
+  posts           Post[]
+  comments        Comment[]
+  orders          Order[]
+  writtenReviews  Review[] @relation("ReviewAuthor")
+  receivedReviews Review[] @relation("ReviewTarget")
+
+  @@map("users")
+  @@schema("public")
+  @@index([createdAt(sort: Desc)], map: "idx_users_created_at")
+  @@index([email, username], type: Hash)
+}
+
+model Profile {
+  id        Int      @id(map: "pk_profile") @default(autoincrement())
+  userId    String   @unique @db.Uuid       @map("user_id")
+  website   String?  @db.VarChar(500)
+  location  String?  @db.VarChar(100)
+  birthDate DateTime? @db.Date              @map("birth_date")
+  timezone  String   @default("UTC")        @db.VarChar(50)
+  /// Raw PostgreSQL hstore — no ORM equivalent, preserved as Unsupported.
+  rawConfig Unsupported("hstore")?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("profiles")
+  @@schema("public")
+}
+
+model Post {
+  id          Int        @id @default(autoincrement())
+  slug        String     @unique              @db.VarChar(255)
+  title       String                          @db.VarChar(500)
+  content     String                          @db.Text
+  excerpt     String?                         @db.VarChar(300)
+  status      PostStatus @default(DRAFT)
+  viewCount   BigInt     @default(0)          @map("view_count")
+  rating      Float      @default(0)          @db.DoublePrecision
+  publishedAt DateTime?  @db.Timestamp(3)     @map("published_at")
+  authorId    String     @db.Uuid             @map("author_id")
+  createdAt   DateTime   @default(now())      @map("created_at")
+  updatedAt   DateTime   @updatedAt           @map("updated_at")
+  /// Internal field excluded from Prisma client — kept in DB for audit.
+  internalNote String?   @ignore              @db.Text @map("internal_note")
+
+  author   User      @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  comments Comment[]
+  tags     Tag[]     // implicit M2M
+  media    Media[]
+
+  @@map("posts")
+  @@schema("public")
+  @@index([status, publishedAt(sort: Desc)])
+  @@index([authorId])
+  @@fulltext([title, content])
+}
+
+model Comment {
+  id        Int      @id @default(autoincrement())
+  content   String   @db.Text
+  postId    Int      @map("post_id")
+  authorId  String   @db.Uuid  @map("author_id")
+  parentId  Int?     @map("parent_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt      @map("updated_at")
+
+  post    Post      @relation(fields: [postId],   references: [id], onDelete: Cascade)
+  author  User      @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  parent  Comment?  @relation("CommentReplies", fields: [parentId], references: [id])
+  replies Comment[] @relation("CommentReplies")
+
+  @@map("comments")
+  @@schema("public")
+  @@index([postId])
+  @@index([authorId])
+}
+
+model Tag {
+  id    Int    @id @default(autoincrement())
+  name  String @unique @db.VarChar(100)
+  slug  String @unique @db.VarChar(100)
+  posts Post[] // implicit M2M back-reference
+
+  @@map("tags")
+  @@schema("public")
+}
+
+model Media {
+  id        Int    @id @default(autoincrement())
+  url       String @db.VarChar(1000)
+  mimeType  String @db.VarChar(100)  @map("mime_type")
+  sizeBytes BigInt @map("size_bytes")
+  width     Int?   @db.SmallInt
+  height    Int?   @db.SmallInt
+  postId    Int    @map("post_id")
+
+  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+
+  @@map("media")
+  @@schema("public")
+}
+
+/// Two distinct relations between User and User (named relations on same model pair).
+model Review {
+  id        Int      @id @default(autoincrement())
+  rating    Int      @db.SmallInt
+  comment   String?  @db.Text
+  authorId  String   @db.Uuid @map("author_id")
+  targetId  String   @db.Uuid @map("target_id")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  author User @relation("ReviewAuthor", fields: [authorId], references: [id])
+  target User @relation("ReviewTarget", fields: [targetId], references: [id])
+
+  @@map("reviews")
+  @@schema("public")
+  @@unique([authorId, targetId], map: "uq_review_author_target")
+}
+
+// ── Shop schema ───────────────────────────────────────────────────────────────
+
+model Product {
+  id          Int     @id(map: "pk_product") @default(autoincrement())
+  sku         String  @unique              @db.VarChar(100)
+  name        String                       @db.VarChar(500)
+  description String?                      @db.Text
+  price       Decimal                      @db.Decimal(10, 2)
+  stock       Int     @default(0)
+  attributes  Json    @default("{}")       @db.JsonB
+  isActive    Boolean @default(true)       @map("is_active")
+  createdAt   DateTime @default(now())     @map("created_at")
+
+  orderItems OrderItem[]
+
+  @@map("products")
+  @@schema("shop")
+  @@index([name(sort: Asc)], type: BTree)
+  @@fulltext([name, description])
+}
+
+model Order {
+  id        Int         @id @default(autoincrement())
+  reference String      @unique @default(dbgenerated("gen_random_uuid()")) @db.VarChar(36)
+  status    OrderStatus @default(PENDING)
+  total     Decimal     @db.Decimal(10, 2)
+  userId    String      @db.Uuid @map("user_id")
+  shippedAt DateTime?   @db.Timestamp(0) @map("shipped_at")
+  createdAt DateTime    @default(now())  @map("created_at")
+  updatedAt DateTime    @updatedAt       @map("updated_at")
+
+  user  User        @relation(fields: [userId], references: [id])
+  items OrderItem[]
+
+  @@map("orders")
+  @@schema("shop")
+  @@index([userId, status])
+  @@index([createdAt(sort: Desc)])
+}
+
+/// Composite PK — (orderId, productId) — no autoincrement id.
+model OrderItem {
+  orderId   Int     @map("order_id")
+  productId Int     @map("product_id")
+  quantity  Int
+  unitPrice Decimal @db.Decimal(10, 2) @map("unit_price")
+
+  order   Order   @relation(fields: [orderId],   references: [id], onDelete: Cascade)
+  product Product @relation(fields: [productId], references: [id])
+
+  @@id([orderId, productId])
+  @@map("order_items")
+  @@schema("shop")
+}
+
+// ── Analytics schema (@@ignore — excluded from Prisma client) ─────────────────
+
+model Event {
+  id         BigInt   @id @default(autoincrement())
+  name       String   @db.VarChar(200)
+  userId     String?  @db.Uuid      @map("user_id")
+  sessionId  String?  @db.Uuid      @map("session_id")
+  payload    Json     @default("{}") @db.JsonB
+  ipAddr     String?  @db.Inet      @map("ip_addr")
+  happenedAt DateTime @default(now()) @db.Timestamptz @map("happened_at")
+
+  @@map("events")
+  @@schema("analytics")
+  @@ignore
+  @@index([name, happenedAt(sort: Desc)])
+}
+
+// ── View ──────────────────────────────────────────────────────────────────────
+
+view UserStats {
+  userId       String @unique @db.Uuid @map("user_id")
+  email        String
+  postCount    Int    @map("post_count")
+  commentCount Int    @map("comment_count")
+  orderCount   Int    @map("order_count")
+
+  @@map("v_user_stats")
+  @@schema("analytics")
+}


### PR DESCRIPTION
## Description

Introduces the foundational abstractions and CLI infrastructure needed to support multiple ORMs in a clean, extensible way.

**Importer/Exporter traits** — defines the `Importer` and `Exporter` contracts that every ORM adapter must satisfy. `PrismaImporter` is the first concrete implementation, wrapping the existing PSL parser.

**ORM registry** — a static registry of `OrmDescriptor` entries (name, file extensions, importer/exporter factories). Exposes `detect()` for extension-based auto-detection and `find_by_name()` for explicit `--from` overrides.

**CLI rewrite** — replaces the hardcoded Prisma-only entrypoint with a proper `clap`-powered CLI. The `convert` subcommand auto-detects the source ORM from the file extension, prompts for confirmation when uncertain, and dispatches to the correct importer via the registry.

**Test fixture** — adds a comprehensive multi-schema Prisma fixture covering UUID PKs, scalar arrays, JSON/JSONB, composite PKs, implicit M2M relations, views, fulltext indexes, and `@ignore` — plus the expected pivot JSON output for regression testing.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Related issues

Closes #

## Acceptance Criteria

- [x] `Importer` and `Exporter` traits are defined and documented
- [x] `PrismaImporter` implements `Importer` and delegates to the existing parser
- [x] Registry detects ORM by file extension and supports lookup by name
- [x] `convert` subcommand accepts a path and an optional `--from <ORM>` flag
- [x] `cargo test` passes (33 unit tests + 6 doc-tests)
- [x] `cargo clippy -- -D warnings` passes with no warnings